### PR TITLE
docs: Spelling mistake in code example

### DIFF
--- a/docs/src/docPages/examples/tiptap.md
+++ b/docs/src/docPages/examples/tiptap.md
@@ -31,7 +31,7 @@ And create your tiptap instance:
 ```js
 import { Editor, StarterKit } from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
-import CollateborationCursor from '@tiptap/extension-collaboration-cursor'
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
 import * as Y from 'yjs'
 import { HocuspocusProvider } from '@hocuspocus/provider'
 


### PR DESCRIPTION
Tiny, but helpful to get this right incase folks are copy/pasting.