### PR TITLE
fix: frontend demo packages are not installed on fresh clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "workspaces": [
     "demos/backend",
-    "demos/client",
+    "demos/frontend",
     "docs",
     "packages/*"
   ],


### PR DESCRIPTION
Alternatively could also use `*` here to make sure a similar error doesn't happen in the future?