### PR TITLE
fix: Empty sync message causes error in client MessageReceiver

### DIFF
--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -43,19 +43,15 @@ export class MessageReceiver {
 
     message.writeVarUint(MessageType.Sync)
 
-    try {
-      const syncMessageType = readSyncMessage(
-        message.decoder,
-        message.encoder,
-        provider.document,
-        provider,
-      )
+    const syncMessageType = readSyncMessage(
+      message.decoder,
+      message.encoder,
+      provider.document,
+      provider,
+    )
 
-      if (emitSynced && syncMessageType === messageYjsSyncStep2) {
-        provider.synced = true
-      }
-    } catch (e) {
-      // TODO: That shouldn’t happen … but it does. Remove the try/catch and run the tests.
+    if (emitSynced && syncMessageType === messageYjsSyncStep2) {
+      provider.synced = true
     }
   }
 

--- a/packages/server/src/IncomingMessage.ts
+++ b/packages/server/src/IncomingMessage.ts
@@ -9,6 +9,7 @@ import {
   Encoder,
   toUint8Array,
   writeVarUint,
+  length,
 } from 'lib0/encoding'
 import { MessageType } from './types'
 
@@ -46,5 +47,9 @@ export class IncomingMessage {
 
   writeVarUint(type: MessageType) {
     writeVarUint(this.encoder, type)
+  }
+
+  get length(): number {
+    return length(this.encoder)
   }
 }

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -28,7 +28,10 @@ export class MessageReceiver {
       case MessageType.Sync:
         message.writeVarUint(MessageType.Sync)
         this.readSyncMessage(message, connection)
-        connection.send(message.toUint8Array())
+
+        if (message.length > 1) {
+          connection.send(message.toUint8Array())
+        }
 
         break
       case MessageType.Awareness:


### PR DESCRIPTION
This check for message length existed previously and was lost here:

https://github.com/ueberdosis/hocuspocus/pull/171/files#diff-e4f9bafbc6bc998e63c12b8e290a9b22d7cf83e21816be901c442135526ab259L179-L181

Resulting in sync messages with no content being sent to the client, breaking assumptions of valid sync messages and causing the caught error.