### PR TITLE
fix (MessageReceiver)[#180]: onChange context value 

### DIFF
--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -56,14 +56,14 @@ export class MessageReceiver {
           break
         }
 
-        readSyncStep2(message.decoder, document, null)
+        readSyncStep2(message.decoder, document, connection)
         break
       case messageYjsUpdate:
         if (connection?.readOnly) {
           break
         }
 
-        readUpdate(message.decoder, document, null)
+        readUpdate(message.decoder, document, connection)
         break
       default:
         throw new Error(`Received a message with an unknown type: ${type}`)

--- a/tests/server/onChange.js
+++ b/tests/server/onChange.js
@@ -11,12 +11,19 @@ context('server/onChange', () => {
     const ydoc = new Y.Doc()
     const Server = new Hocuspocus()
 
+    const mockContext = {
+      userId: '12345',
+    }
     let triggered = false
 
     Server.configure({
       port: 4000,
-      async onChange({ document }) {
+      async onConnect() {
+        return mockContext
+      },
+      async onChange({ document, context }) {
         const value = document.getArray('foo').get(0)
+        assert.deepStrictEqual(context, mockContext)
 
         if (!triggered && value === 'bar') {
           triggered = true


### PR DESCRIPTION
# Changes
- Passes the current `connection` to readSyncStep2 and readUpdate in MessageReceiver
- This restores the previous behavior before #171 

# Context
Addresses #180 