### PR TITLE
Allow passing token as a function that returns a promise

### DIFF
--- a/tests/provider/onAuthenticated.js
+++ b/tests/provider/onAuthenticated.js
@@ -33,4 +33,58 @@ context('provider/onAuthenticated', () => {
       },
     })
   })
+
+  it('executes the onAuthenticated callback when token is provided as a function that returns a promise', done => {
+    const Server = new Hocuspocus()
+
+    Server.configure({
+      port: 4000,
+      async onAuthenticate({ token }) {
+        if (token !== 'SUPER-SECRET-TOKEN') {
+          throw new Error()
+        }
+      },
+    }).listen()
+
+    client = new HocuspocusProvider({
+      url: 'ws://127.0.0.1:4000',
+      name: 'hocuspocus-test',
+      document: ydoc,
+      WebSocketPolyfill: WebSocket,
+      token: () => Promise.resolve('SUPER-SECRET-TOKEN'),
+      onAuthenticated: () => {
+        client.destroy()
+        Server.destroy()
+
+        done()
+      },
+    })
+  })
+
+  it('executes the onAuthenticated callback when token is provided as a function that returns a string', done => {
+    const Server = new Hocuspocus()
+
+    Server.configure({
+      port: 4000,
+      async onAuthenticate({ token }) {
+        if (token !== 'SUPER-SECRET-TOKEN') {
+          throw new Error()
+        }
+      },
+    }).listen()
+
+    client = new HocuspocusProvider({
+      url: 'ws://127.0.0.1:4000',
+      name: 'hocuspocus-test',
+      document: ydoc,
+      WebSocketPolyfill: WebSocket,
+      token: () => 'SUPER-SECRET-TOKEN',
+      onAuthenticated: () => {
+        client.destroy()
+        Server.destroy()
+
+        done()
+      },
+    })
+  })
 })


### PR DESCRIPTION
As discussed in #190, with these changes it would be possible to pass the token also as a function that either returns `string` or `Promise<string>`, therefore allowing the token be retrieved right before the `AuthenticationMessage` is sent.  