### PR TITLE
feat: Add `connectionsCount` and `documentsCount` methods to server

### DIFF
--- a/docs/src/docPages/api/methods.md
+++ b/docs/src/docPages/api/methods.md
@@ -11,6 +11,8 @@ Our goal: Let’s keep it simple. The server has a few methods only.
 | `listen()`                                                   | Start the server.                                 |
 | `configure(configuration)`                                   | Pass custom settings.                             |
 | `handleConnection(incoming, request, documentName, context)` | Bind the server to an existing server instance.   |
+| `documentsCount()`                                           | Get the total number of active documents          |
+| `connectionsCount()`                                         | Get the total number of active connections        |
 | `closeConnections(documentName?)`                            | Close all connections, or to a specific document. |
 | `destroy()`                                                  | Stop the server.                                  |
 

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -104,7 +104,7 @@ class Document extends Doc {
   }
 
   /**
-   * Get the number of active connections
+   * Get the number of active connections for this document
    */
   connectionsCount(): number {
     return this.connections.size

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -139,6 +139,23 @@ export class Hocuspocus {
   }
 
   /**
+   * Get the total number of active documents
+   */
+  documentsCount(): number {
+    return this.documents.size
+  }
+
+  /**
+   * Get the total number of active connections
+   */
+  connectionsCount(): number {
+    return Array.from(this.documents.values()).reduce((acc, document) => {
+      acc += document.connectionsCount()
+      return acc
+    }, 0)
+  }
+
+  /**
    * Force close one or more connections
    */
   closeConnections(documentName?: string) {

--- a/tests/server/connectionsCount.js
+++ b/tests/server/connectionsCount.js
@@ -1,0 +1,45 @@
+// import assert from 'assert'
+import * as Y from 'yjs'
+import WebSocket from 'ws'
+import { assert } from 'chai'
+import { Hocuspocus } from '../../packages/server/src'
+import { HocuspocusProvider } from '../../packages/provider/src'
+
+const ydoc = new Y.Doc()
+
+context('server/connectionsCount', () => {
+  it('outputs the total connections', done => {
+    const Server = new Hocuspocus()
+
+    Server.configure({
+      port: 4000,
+    })
+
+    Server.listen()
+
+    const client = new HocuspocusProvider({
+      url: 'ws://127.0.0.1:4000',
+      name: 'hocuspocus-test',
+      document: ydoc,
+      WebSocketPolyfill: WebSocket,
+      onSynced() {
+        assert.strictEqual(Server.connectionsCount(), 1)
+
+        const client2 = new HocuspocusProvider({
+          url: 'ws://127.0.0.1:4000',
+          name: 'hocuspocus-test2',
+          document: ydoc,
+          WebSocketPolyfill: WebSocket,
+          onSynced() {
+            assert.strictEqual(Server.connectionsCount(), 2)
+
+            client2.destroy()
+            client.destroy()
+            Server.destroy()
+            done()
+          },
+        })
+      },
+    })
+  })
+})

--- a/tests/server/documentsCount.js
+++ b/tests/server/documentsCount.js
@@ -1,0 +1,34 @@
+// import assert from 'assert'
+import * as Y from 'yjs'
+import WebSocket from 'ws'
+import { assert } from 'chai'
+import { Hocuspocus } from '../../packages/server/src'
+import { HocuspocusProvider } from '../../packages/provider/src'
+
+const ydoc = new Y.Doc()
+
+context('server/documentsCount', () => {
+  it('outputs the total active documents', done => {
+    const Server = new Hocuspocus()
+
+    Server.configure({
+      port: 4000,
+    })
+
+    Server.listen()
+
+    const client = new HocuspocusProvider({
+      url: 'ws://127.0.0.1:4000',
+      name: 'hocuspocus-test',
+      document: ydoc,
+      WebSocketPolyfill: WebSocket,
+      onSynced() {
+        assert.strictEqual(Server.documentsCount(), 1)
+
+        client.destroy()
+        Server.destroy()
+        done()
+      },
+    })
+  })
+})


### PR DESCRIPTION
Anyone running in a production environment will need the equivalent of these methods to keep track of what the server is upto.