### PR TITLE
fix: Error thrown from retry post-destroy

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -567,6 +567,11 @@ export class HocuspocusProvider extends EventEmitter {
 
     removeAwarenessStates(this.awareness, [this.document.clientID], 'provider destroy')
 
+    // If there is still a connection attempt outstanding then we should resolve
+    // it before calling disconnect, otherwise it will be rejected in the onClose
+    // handler and trigger a retry
+    this.resolveConnectionAttempt()
+
     this.disconnect()
 
     this.awareness.off('update', this.awarenessUpdateHandler)


### PR DESCRIPTION
So, annoyingly the last two fixes #216 and #217 ended up interacting in a previously unpredictable way when destroying a provider:

- The `destroy` method disconnects the websocket
- `disconnect` calls `onClose` which will retry the connection if `connectionAttempt` is outstanding
- But the connection is already disconnected (`shouldConnect=false`) so we hit the `context.abort()` clause, which throws an error 🤷 

---

A couple of improvements:

a) Move the disconnecting of the websocket after `removeAwarenessStates`
b) Catch and swallow errors from aborted retries, these are expected and should not bubble up 
c) Cleanup any outstanding `connectionAttempt` before calling disconnect