### PR TITLE
fix: Remove event listener once unused

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -279,6 +279,7 @@ export class Hocuspocus {
             // connection is closed
             incoming.send(message.toUint8Array(), () => {
               incoming.close(Forbidden.code, Forbidden.reason)
+              incoming.off('message', queueIncomingMessageListener)
             })
           })
       } else {
@@ -296,6 +297,7 @@ export class Hocuspocus {
       .catch(error => {
         // if a hook interrupts, close the websocket connection
         incoming.close(Forbidden.code, Forbidden.reason)
+        incoming.off('message', queueIncomingMessageListener)
 
         if (error) {
           throw error


### PR DESCRIPTION
This might make all the difference or none at all, I'm honestly not sure. But we should cleanup these listeners as the functions hold closures and potentially keep memory around longer than needed – the most likely candidate I've found so far.

Relates #206 