### PR TITLE
fix: Destroy document when last user disconnects

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -413,15 +413,20 @@ export class Hocuspocus {
         requestParameters: Hocuspocus.getParameters(request),
       }
 
+      // Remove the document from the map immediately before the hooks are called
+      // as these may take some time to resolve (eg persist to database). If a
+      // new connection were to come in during that time it would rely on the
+      // document in the map that we later remove.
+      if (document.getConnectionsCount() <= 0) {
+        this.documents.delete(document.name)
+      }
+
       this.hooks('onDisconnect', hookPayload)
         .catch(e => {
           throw e
         })
         .finally(() => {
-          if (document.getConnectionsCount() <= 0) {
-            document.destroy()
-            this.documents.delete(document.name)
-          }
+          document.destroy()
         })
     })
 


### PR DESCRIPTION
I was able to download memory heaps from production and it immediately became obvious what the issue was – we never call `doc.destroy()` which is [listened to in the Awareness class to remove](https://github.com/yjs/y-protocols/blob/master/awareness.js#L78-L80) timers. Without this destroy call every doc is retained in memory by the awareness intervals.

Debugging this I also looked at the [original implementation](https://github.com/yjs/y-websocket/blame/caa6304ba30c0e6d5921e735470f6470b045cb6a/bin/utils.js#L203-L205) in y-websocket, you can see here that the doc is removed from the map _before_ awaiting persistence hooks – this is important as these hooks are async.

closes #206 