### PR TITLE
Fix: Fix path to extension webhook typings

### DIFF
--- a/packages/extension-webhook/package.json
+++ b/packages/extension-webhook/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "main": "dist/hocuspocus-webhook.esm.js",
   "module": "dist/hocuspocus-webhook.esm.js",
-  "types": "dist/packages/webhook/src/index.d.ts",
+  "types": "dist/packages/extension-webhook/src/index.d.ts",
   "exports": {
     "source": {
       "import": "./src"


### PR DESCRIPTION
The path to the typings file for the webhook extension is currently broken. This PR should resolve this issue.