### PR TITLE
Pass websocket error to reject(); fixes #359

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -305,8 +305,8 @@ export class HocuspocusProvider extends EventEmitter {
       ws.onmessage = this.onMessage.bind(this)
       ws.onclose = this.onClose.bind(this)
       ws.onopen = this.onOpen.bind(this)
-      ws.onerror = () => {
-        reject()
+      ws.onerror = (err: any) => {
+        reject(err)
       }
       this.webSocket = ws
 


### PR DESCRIPTION
With this PR, the websocket error will be passed to the reject() to allow custom error handling. 

Thanks to @deeg for providing the patch!