### PR TITLE
Pass custom CloseEvent to connection if returned by onConnect hook

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -9,6 +9,7 @@ import {
   ResetConnection,
   Unauthorized,
   Forbidden,
+  CloseEvent,
   awarenessStatesToArray,
   WsReadyStates,
 } from '@hocuspocus/common'
@@ -495,9 +496,9 @@ export class Hocuspocus {
         // Authentication isn’t required, let’s establish the connection
         return setUpNewConnection(queueIncomingMessageListener)
       })
-      .catch(() => {
+      .catch((reason = Forbidden) => {
         // if a hook interrupts, close the websocket connection
-        incoming.close(Forbidden.code, Forbidden.reason)
+        incoming.close(reason.code ?? Forbidden.code, reason.reason ?? Forbidden.reason)
         incoming.off('message', queueIncomingMessageListener)
       })
   }


### PR DESCRIPTION
This fixes #369.

When a custom error is thrown by the onConnect hook, it will be passed on to the connection. The default is Forbidden, as before. 

This allows the following:

(server):
```
   async onConnect() {
      const outdatedSchemaError: CloseEvent = {
          code: 1001,
          reason: "Schema is outdated"
      }

      throw outdatedSchemaError;
    },
```

(client):
```
  onClose(data){
    console.log(data.event.code);
    console.log(data.event.reason);
  },

```