### PR TITLE
extension-webhook: send proper content-type header: application/json

### DIFF
--- a/packages/extension-webhook/src/index.ts
+++ b/packages/extension-webhook/src/index.ts
@@ -97,7 +97,7 @@ export class Webhook implements Extension {
     return axios.post(
       this.configuration.url,
       json,
-      { headers: { 'X-Hocuspocus-Signature-256': this.createSignature(json) } },
+      { headers: { 'X-Hocuspocus-Signature-256': this.createSignature(json), 'Content-Type': 'application/json' } },
     )
   }
 


### PR DESCRIPTION
Webhooks sent by hocuspocus should send the correct `Application-Type` header: `application/json`