### PR TITLE
Revert "Fixes #382: if onLoadDocument throws an error, an empty document stays in the document cache that will eventually replace the actual document when storing"

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -588,6 +588,7 @@ export class Hocuspocus {
     }
 
     const document = new Document(documentName, this.debugger, this.configuration.yDocOptions)
+    this.documents.set(documentName, document)
 
     const hookPayload = {
       instance: this,
@@ -612,7 +613,6 @@ export class Hocuspocus {
       }
     })
 
-    this.documents.set(documentName, document)
     await this.hooks('afterLoadDocument', hookPayload)
 
     document.onUpdate((document: Document, connection: Connection, update: Uint8Array) => {

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -168,11 +168,8 @@ test('stops when an error is thrown in onLoadDocument', async t => {
       }
     })
 
-    t.is(server.documents.size, 0);
-
     newHocuspocusProvider(server, {
       onClose() {
-        t.is(server.documents.size, 0);
         t.pass()
         resolve('done')
       }
@@ -191,12 +188,9 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
       }
     })
 
-    t.is(server.documents.size, 0);
-
     newHocuspocusProvider(server, {
       token: 'super-secret-token',
       onClose() {
-        t.is(server.documents.size, 0);
         t.pass()
         resolve('done')
       }


### PR DESCRIPTION
Reverts ueberdosis/hocuspocus#384