### PR TITLE
docs/cli: Use npx

### DIFF
--- a/docs/installation/cli.md
+++ b/docs/installation/cli.md
@@ -36,16 +36,16 @@ hocuspocus --sqlite
 
 ```bash
 npm install @hocuspocus/cli
-./node_modules/.bin/@hocuspocus/cli
-./node_modules/.bin/@hocuspocus/cli --port 8080
-./node_modules/.bin/@hocuspocus/cli --webhook http://localhost/webhooks/hocuspocus
-./node_modules/.bin/@hocuspocus/cli --sqlite
+npx hocuspocus
+npx hocuspocus --port 8080
+npx hocuspocus --webhook http://localhost/webhooks/hocuspocus
+npx hocuspocus --sqlite
 ```
 
 ```bash
 yarn add @hocuspocus/cli
-./node_modules/.bin/@hocuspocus/cli
-./node_modules/.bin/@hocuspocus/cli --port 8080
-./node_modules/.bin/@hocuspocus/cli --webhook http://localhost/webhooks/hocuspocus
-./node_modules/.bin/@hocuspocus/cli --sqlite
+npx hocuspocus
+npx hocuspocus --port 8080
+npx hocuspocus --webhook http://localhost/webhooks/hocuspocus
+npx hocuspocus --sqlite
 ```


### PR DESCRIPTION
npx executes binaries from local packages, which is easier and more future proof than using node_modules paths.

npx is pre-bundled with npm since [v5.2.0](https://github.com/npm/npm/releases/tag/v5.2.0)