### PR TITLE
Add instructions to compile code

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,6 +28,12 @@ It’s not too hard to tinker around with the official repository. You’ll need
 4. Open http://localhost:3000 in your favorite browser.
 5. Start playing around!
 
+Compile and watch for changes:
+
+```sh
+npm run build:watch
+```
+
 ## Our code style
 There is an eslint config that ensures a consistent code style. To check for errors, run `$ npm run lint`. That’ll be checked when you send a pull request, too. Make sure it’s passing, before sending a pull request.
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:watch": "ava --watch",
     "build:packages": "npm run clean:packages && rollup -c && npm run build:dashboard",
     "build:dashboard": "npm --prefix packages/extension-monitor run build",
+    "build:watch": "npm run clean:packages && rollup -wc",
     "clean:packages": "rm -Rf ./packages/*/dist",
     "release:major": "lerna version major --force-publish",
     "release:major:pre": "lerna version premajor --force-publish",


### PR DESCRIPTION
It took me a bit to figure out how to compile the code in the project. I could not find documentation or an npm script.

`rollup -wc` worked for me, but let me know if there is a different way that is recommended.

This pull request adds a `build:watch` npm script and instructions in `contributing.md` for compiling the project.