### PR TITLE
feature/multiplexing: Call setUpNewConnection once onConnect

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -152,7 +152,7 @@ export class Redis implements Extension {
    * Publish the first sync step through Redis.
    */
   private async publishFirstSyncStep(documentName: string, document: Document) {
-    const syncMessage = new OutgoingMessage()
+    const syncMessage = new OutgoingMessage(documentName)
       .createSyncMessage()
       .writeFirstSyncStepFor(document)
 
@@ -163,7 +163,7 @@ export class Redis implements Extension {
    * Let’s ask Redis who is connected already.
    */
   private async requestAwarenessFromOtherInstances(documentName: string) {
-    const awarenessMessage = new OutgoingMessage()
+    const awarenessMessage = new OutgoingMessage(documentName)
       .writeQueryAwareness()
 
     return this.pub.publishBuffer(
@@ -216,7 +216,7 @@ export class Redis implements Extension {
     documentName, awareness, added, updated, removed,
   }: onAwarenessUpdatePayload) {
     const changedClients = added.concat(updated, removed)
-    const message = new OutgoingMessage()
+    const message = new OutgoingMessage(documentName)
       .createAwarenessUpdateMessage(awareness, changedClients)
 
     return this.pub.publishBuffer(

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -493,11 +493,6 @@ export class Hocuspocus {
                 incoming.off('message', queueIncomingMessageListener)
               })
             })
-        } else if (!connection.requiresAuthentication) {
-          console.log('queueIncomingMessageListener: auth not required, setUpNewConnection')
-          incomingMessageQueue.push(data)
-
-          return setUpNewConnection(hookPayload.documentName, queueIncomingMessageListener)
         } else {
           console.log('queueIncomingMessageListener: queueing')
 
@@ -550,6 +545,14 @@ export class Hocuspocus {
         context = { ...context, ...contextAdditions }
         console.log('onConnect finished')
       })
+        .then(() => {
+          // Authentication is required, we’ll need to wait for the Authentication message.
+          if (connection.requiresAuthentication && !connection.isAuthenticated) {
+            return
+          }
+
+          return setUpNewConnection(hookPayload.documentName, queueIncomingMessageListener)
+        })
         .catch((error = Forbidden) => {
           console.log('caught error during onConnect')
           // if a hook interrupts, close the websocket connection


### PR DESCRIPTION
This is my initial contribution to #484. Still getting to know the codebase, but hoping to help move the multiplexing feature forward.

- Fixed OutgoingMessage types in Redis extension
- Partially reverted server to call setupNewConnection once after onConnect has finished

Calling `setUpNewConnection` was being called multiple times, resulting in duplicate queue emits. Calling `setUpNewConnection` with `hookPayload.documentName` after the `onConnect` hooks completes fixes some of the failing server and provider tests.

I am quite new to the codebase, so please let me know if `setUpNewConnection` was moved for a reason. I assume it was an attempt to clean up the code, but had an unintended regression.