### PR TITLE
Run the build action on all PR's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
   lint:


### PR DESCRIPTION
The current GitHub workflow only runs actions when PR's are opened against `main`. It is probably beneficial to run them on any PR. This makes it easier to contribute to draft PR's. 

For example: 
[ueberdosis:feature/multiplexing](https://github.com/ueberdosis/hocuspocus/tree/feature/multiplexing)  (#484) ← [raineorshine:feature/multiplexing](https://github.com/raineorshine/hocuspocus/tree/feature/multiplexing) (#495)