### PR TITLE
feature: remove node-static in favor of serve-handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5217,14 +5217,6 @@
       "version": "1.2.0",
       "license": "MIT"
     },
-    "node_modules/@types/node-static": {
-      "version": "0.7.7",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "license": "MIT"
@@ -5381,6 +5373,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-handler": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
+      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8637,13 +8638,6 @@
       "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
       "dependencies": {
         "lerp": "^1.0.3"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/columnify": {
@@ -12164,6 +12158,19 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "license": "MIT"
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/fastparse": {
       "version": "1.1.2",
@@ -17483,21 +17490,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
-    "node_modules/node-static": {
-      "version": "0.7.11",
-      "license": "MIT",
-      "dependencies": {
-        "colors": ">=0.6.0",
-        "mime": "^1.2.9",
-        "optimist": ">=0.3.4"
-      },
-      "bin": {
-        "static": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 0.4.1"
-      }
-    },
     "node_modules/nodemon": {
       "version": "2.0.15",
       "dev": true,
@@ -18052,18 +18044,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "license": "MIT/X11",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.8.3",
@@ -18835,6 +18815,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w=="
     },
     "node_modules/path-is-network-drive": {
       "version": "1.0.13",
@@ -22105,6 +22090,69 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.2",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+    },
+    "node_modules/serve-handler/node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/serve-static": {
@@ -25498,13 +25546,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/world-calendars": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
@@ -25908,13 +25949,13 @@
     },
     "packages/cli": {
       "name": "@hocuspocus/cli",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-sqlite": "^1.0.0-beta.7",
-        "@hocuspocus/extension-webhook": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-sqlite": "^1.0.0",
+        "@hocuspocus/extension-webhook": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
         "meow": "^11.0.0"
       },
       "bin": {
@@ -26276,7 +26317,7 @@
     },
     "packages/common": {
       "name": "@hocuspocus/common",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.47"
@@ -26284,10 +26325,10 @@
     },
     "packages/extension-database": {
       "name": "@hocuspocus/extension-database",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       },
       "peerDependencies": {
         "yjs": "^13.5.29"
@@ -26295,26 +26336,25 @@
     },
     "packages/extension-logger": {
       "name": "@hocuspocus/extension-logger",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       }
     },
     "packages/extension-monitor": {
       "name": "@hocuspocus/extension-monitor",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/server": "^1.0.0",
         "@types/node-os-utils": "^1.2.0",
-        "@types/node-static": "^0.7.7",
         "bufferutil": "^4.0.6",
         "collect.js": "^4.32.0",
         "moment": "^2.29.1",
         "node-os-utils": "^1.3.6",
-        "node-static": "^0.7.11",
         "public-ip": "^6.0.1",
+        "serve-handler": "^6.1.5",
         "tailwindcss-font-inter": "^3.0.1",
         "vue": "^2.6.14",
         "vue-plotly": "^1.1.0",
@@ -26324,6 +26364,7 @@
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^5.0.0",
         "@tailwindcss/postcss7-compat": "npm:@tailwindcss/postcss7-compat",
+        "@types/serve-handler": "^6.1.1",
         "autoprefixer": "^10.4.13",
         "collect.js": "^4.32.0",
         "moment": "^2.29.1",
@@ -26540,10 +26581,10 @@
     },
     "packages/extension-redis": {
       "name": "@hocuspocus/extension-redis",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/server": "^1.0.0",
         "ioredis": "^4.28.2",
         "kleur": "^4.1.4",
         "lodash.debounce": "^4.0.8",
@@ -26570,10 +26611,10 @@
     },
     "packages/extension-sqlite": {
       "name": "@hocuspocus/extension-sqlite",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/extension-database": "^1.0.0-beta.7",
+        "@hocuspocus/extension-database": "^1.0.0",
         "kleur": "^4.1.4",
         "sqlite3": "^5.0.11"
       },
@@ -26583,20 +26624,20 @@
     },
     "packages/extension-throttle": {
       "name": "@hocuspocus/extension-throttle",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       }
     },
     "packages/extension-webhook": {
       "name": "@hocuspocus/extension-webhook",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "axios": "^1.2.2"
       },
       "peerDependencies": {
@@ -26605,10 +26646,10 @@
     },
     "packages/provider": {
       "name": "@hocuspocus/provider",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
         "@lifeomic/attempt": "^3.0.2",
         "lib0": "^0.2.46"
       },
@@ -26619,10 +26660,10 @@
     },
     "packages/server": {
       "name": "@hocuspocus/server",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
         "@types/async-lock": "^1.1.3",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.5.3",
@@ -26667,7 +26708,7 @@
     },
     "packages/transformer": {
       "name": "@hocuspocus/transformer",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^2.0.0-beta.174",
@@ -26681,15 +26722,15 @@
     },
     "playground/backend": {
       "name": "@hocuspocus/server-demos",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-monitor": "^1.0.0-beta.7",
-        "@hocuspocus/extension-redis": "^1.0.0-beta.7",
-        "@hocuspocus/extension-sqlite": "^1.0.0-beta.7",
-        "@hocuspocus/extension-webhook": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-monitor": "^1.0.0",
+        "@hocuspocus/extension-redis": "^1.0.0",
+        "@hocuspocus/extension-sqlite": "^1.0.0",
+        "@hocuspocus/extension-webhook": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "@tiptap/core": "^2.0.0-beta.174",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@types/express": "^4.17.13",
@@ -26709,9 +26750,9 @@
     },
     "playground/frontend": {
       "name": "@hocuspocus/provider-demos",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "dependencies": {
-        "@hocuspocus/provider": "^1.0.0-beta.7",
+        "@hocuspocus/provider": "^1.0.0",
         "@tiptap/extension-collaboration": "^2.0.0-beta.33",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@tiptap/vue-2": "^2.0.0-beta.77",
@@ -26901,14 +26942,14 @@
       }
     },
     "tests": {
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-redis": "^1.0.0-beta.7",
-        "@hocuspocus/extension-throttle": "^1.0.0-beta.7",
-        "@hocuspocus/provider": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-redis": "^1.0.0",
+        "@hocuspocus/extension-throttle": "^1.0.0",
+        "@hocuspocus/provider": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "node-fetch": "^3.2.3",
         "redis": "^4.0.4",
         "sinon": "^12.0.1",
@@ -28264,10 +28305,10 @@
     "@hocuspocus/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-sqlite": "^1.0.0-beta.7",
-        "@hocuspocus/extension-webhook": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-sqlite": "^1.0.0",
+        "@hocuspocus/extension-webhook": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
         "meow": "^11.0.0"
       },
       "dependencies": {
@@ -28492,32 +28533,32 @@
     "@hocuspocus/extension-database": {
       "version": "file:packages/extension-database",
       "requires": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       }
     },
     "@hocuspocus/extension-logger": {
       "version": "file:packages/extension-logger",
       "requires": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       }
     },
     "@hocuspocus/extension-monitor": {
       "version": "file:packages/extension-monitor",
       "requires": {
         "@fullhuman/postcss-purgecss": "^5.0.0",
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/server": "^1.0.0",
         "@tailwindcss/postcss7-compat": "npm:@tailwindcss/postcss7-compat",
         "@types/node-os-utils": "^1.2.0",
-        "@types/node-static": "^0.7.7",
+        "@types/serve-handler": "^6.1.1",
         "autoprefixer": "^10.4.13",
         "bufferutil": "^4.0.6",
         "collect.js": "^4.32.0",
         "moment": "^2.29.1",
         "node-os-utils": "^1.3.6",
-        "node-static": "^0.7.11",
         "parcel-bundler": "^1.12.3",
         "postcss": "^8",
         "public-ip": "^6.0.1",
+        "serve-handler": "^6.1.5",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat",
         "tailwindcss-font-inter": "^3.0.1",
         "vue": "^2.6.14",
@@ -28645,7 +28686,7 @@
     "@hocuspocus/extension-redis": {
       "version": "file:packages/extension-redis",
       "requires": {
-        "@hocuspocus/server": "^1.0.0-beta.7",
+        "@hocuspocus/server": "^1.0.0",
         "@types/ioredis": "^4.28.7",
         "@types/lodash.debounce": "^4.0.6",
         "@types/redlock": "^4.0.3",
@@ -28666,7 +28707,7 @@
     "@hocuspocus/extension-sqlite": {
       "version": "file:packages/extension-sqlite",
       "requires": {
-        "@hocuspocus/extension-database": "^1.0.0-beta.7",
+        "@hocuspocus/extension-database": "^1.0.0",
         "@types/sqlite3": "^3.1.8",
         "kleur": "^4.1.4",
         "sqlite3": "^5.0.11"
@@ -28675,22 +28716,22 @@
     "@hocuspocus/extension-throttle": {
       "version": "file:packages/extension-throttle",
       "requires": {
-        "@hocuspocus/server": "^1.0.0-beta.7"
+        "@hocuspocus/server": "^1.0.0"
       }
     },
     "@hocuspocus/extension-webhook": {
       "version": "file:packages/extension-webhook",
       "requires": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "axios": "^1.2.2"
       }
     },
     "@hocuspocus/provider": {
       "version": "file:packages/provider",
       "requires": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
         "@lifeomic/attempt": "^3.0.2",
         "lib0": "^0.2.46"
       }
@@ -28698,7 +28739,7 @@
     "@hocuspocus/provider-demos": {
       "version": "file:playground/frontend",
       "requires": {
-        "@hocuspocus/provider": "^1.0.0-beta.7",
+        "@hocuspocus/provider": "^1.0.0",
         "@tiptap/extension-collaboration": "^2.0.0-beta.33",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@tiptap/vue-2": "^2.0.0-beta.77",
@@ -28819,7 +28860,7 @@
     "@hocuspocus/server": {
       "version": "file:packages/server",
       "requires": {
-        "@hocuspocus/common": "^1.0.0-beta.7",
+        "@hocuspocus/common": "^1.0.0",
         "@types/async-lock": "^1.1.3",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.5.3",
@@ -28846,13 +28887,13 @@
     "@hocuspocus/server-demos": {
       "version": "file:playground/backend",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-monitor": "^1.0.0-beta.7",
-        "@hocuspocus/extension-redis": "^1.0.0-beta.7",
-        "@hocuspocus/extension-sqlite": "^1.0.0-beta.7",
-        "@hocuspocus/extension-webhook": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-monitor": "^1.0.0",
+        "@hocuspocus/extension-redis": "^1.0.0",
+        "@hocuspocus/extension-sqlite": "^1.0.0",
+        "@hocuspocus/extension-webhook": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "@tiptap/core": "^2.0.0-beta.174",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@types/express": "^4.17.13",
@@ -31266,13 +31307,6 @@
     "@types/node-os-utils": {
       "version": "1.2.0"
     },
-    "@types/node-static": {
-      "version": "0.7.7",
-      "requires": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
     "@types/normalize-package-data": {
       "version": "2.4.1"
     },
@@ -31415,6 +31449,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-handler": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
+      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -33786,9 +33829,6 @@
       "requires": {
         "lerp": "^1.0.3"
       }
-    },
-    "colors": {
-      "version": "1.4.0"
     },
     "columnify": {
       "version": "1.5.4",
@@ -36388,6 +36428,21 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6"
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+        }
+      }
     },
     "fastparse": {
       "version": "1.1.2",
@@ -40359,14 +40414,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
-    "node-static": {
-      "version": "0.7.11",
-      "requires": {
-        "colors": ">=0.6.0",
-        "mime": "^1.2.9",
-        "optimist": ">=0.3.4"
-      }
-    },
     "nodemon": {
       "version": "2.0.15",
       "dev": true,
@@ -40749,18 +40796,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10"
-        }
       }
     },
     "optionator": {
@@ -41333,6 +41368,11 @@
     },
     "path-is-absolute": {
       "version": "1.0.1"
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w=="
     },
     "path-is-network-drive": {
       "version": "1.0.13",
@@ -43793,6 +43833,56 @@
       "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
       "dev": true
     },
+    "serve-handler": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.2",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="
+        }
+      }
+    },
     "serve-static": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
@@ -45080,12 +45170,12 @@
     "tests": {
       "version": "file:tests",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0-beta.7",
-        "@hocuspocus/extension-redis": "^1.0.0-beta.7",
-        "@hocuspocus/extension-throttle": "^1.0.0-beta.7",
-        "@hocuspocus/provider": "^1.0.0-beta.7",
-        "@hocuspocus/server": "^1.0.0-beta.7",
-        "@hocuspocus/transformer": "^1.0.0-beta.7",
+        "@hocuspocus/extension-logger": "^1.0.0",
+        "@hocuspocus/extension-redis": "^1.0.0",
+        "@hocuspocus/extension-throttle": "^1.0.0",
+        "@hocuspocus/provider": "^1.0.0",
+        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/transformer": "^1.0.0",
         "@types/redis": "^4.0.11",
         "@types/sinon": "^10.0.11",
         "lib0": "^0.2.47",
@@ -46445,9 +46535,6 @@
     },
     "word-wrap": {
       "version": "1.2.3"
-    },
-    "wordwrap": {
-      "version": "0.0.3"
     },
     "world-calendars": {
       "version": "1.0.3",

--- a/packages/extension-monitor/package.json
+++ b/packages/extension-monitor/package.json
@@ -40,13 +40,12 @@
   "dependencies": {
     "@hocuspocus/server": "^1.0.0",
     "@types/node-os-utils": "^1.2.0",
-    "@types/node-static": "^0.7.7",
     "bufferutil": "^4.0.6",
     "collect.js": "^4.32.0",
     "moment": "^2.29.1",
     "node-os-utils": "^1.3.6",
-    "node-static": "^0.7.11",
     "public-ip": "^6.0.1",
+    "serve-handler": "^6.1.5",
     "tailwindcss-font-inter": "^3.0.1",
     "vue": "^2.6.14",
     "vue-plotly": "^1.1.0",
@@ -59,6 +58,7 @@
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^5.0.0",
     "@tailwindcss/postcss7-compat": "npm:@tailwindcss/postcss7-compat",
+    "@types/serve-handler": "^6.1.1",
     "autoprefixer": "^10.4.13",
     "collect.js": "^4.32.0",
     "moment": "^2.29.1",

--- a/packages/extension-monitor/src/Dashboard.ts
+++ b/packages/extension-monitor/src/Dashboard.ts
@@ -2,7 +2,7 @@ import { createServer, IncomingMessage, ServerResponse } from 'http'
 import WebSocket, { WebSocketServer } from 'ws'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
-import { Server as NodeStaticServer } from 'node-static'
+import staticHandler from 'serve-handler'
 import { Socket } from 'net'
 import process from 'process'
 import { Storage } from './Storage'
@@ -87,9 +87,8 @@ export class Dashboard {
       request.url = request.url.replace(path, '')
 
       const publicPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'dashboard', 'dist')
-      const server = new NodeStaticServer(publicPath, { cache: 0 })
 
-      request.addListener('end', () => server.serve(request, response)).resume()
+      request.addListener('end', () => staticHandler(request, response, { public: publicPath })).resume()
 
       return true
     }


### PR DESCRIPTION
I’ve removed `node-static` in favor of [serve-handler](https://github.com/vercel/serve-handler) in the monitor extension package.

This should resolve the security issue mentioned in https://github.com/ueberdosis/hocuspocus/issues/491

Let me know if something seems off with this approach ✌️ 