### PR TITLE
Handle errors caused by incorrect websocket close codes in auth hook

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -471,7 +471,14 @@ export class Hocuspocus {
               // Ensure that the permission denied message is sent before the
               // connection is closed
               incoming.send(message.toUint8Array(), () => {
-                incoming.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
+                try {
+                  incoming.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
+                } catch (closeError) {
+                  // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
+                  console.error(closeError);
+                  incoming.close(Forbidden.code, Forbidden.reason);
+                }
+
                 incoming.off('message', queueIncomingMessageListener)
               })
             })

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -475,8 +475,8 @@ export class Hocuspocus {
                   incoming.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
                 } catch (closeError) {
                   // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
-                  console.error(closeError);
-                  incoming.close(Forbidden.code, Forbidden.reason);
+                  console.error(closeError)
+                  incoming.close(Forbidden.code, Forbidden.reason)
                 }
 
                 incoming.off('message', queueIncomingMessageListener)


### PR DESCRIPTION
We have seen crashes coming from the authorization hook, so I think we need to make the same change as https://github.com/ueberdosis/hocuspocus/pull/468 to prevent the crashing.
In particular from the below stack trace `@hocuspocus/server/src/Hocuspocus.ts:474`.
https://github.com/ueberdosis/hocuspocus/blob/cb21edca148bb63fcd890e594d789637f65712c0/packages/server/src/Hocuspocus.ts#L474


{"stack":"TypeError: First argument must be a valid error code number\n    at Sender.close (/app/node_modules/.pnpm/ws@8.5.0/node_modules/ws/lib/sender.js:162:13)\n    at WebSocket.close (/app/node_modules/.pnpm/ws@8.5.0/node_modules/ws/lib/websocket.js:299:18)\n    at /app/node_modules/.pnpm/@hocuspocus+server@1.0.0_yjs@/node_modules/@hocuspocus/server/src/Hocuspocus.ts:474:26\n    at onCorkedFinish (_stream_writable.js:673:5)\n    at afterWrite (_stream_writable.js:490:5)\n    at afterWriteTick (_stream_writable.js:477:10)\n    at processTicksAndRejections (internal/process/task_queues.js:83:21)","message":"First argument must be a valid error code number"
