### PR TITLE
chore: synchronize package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25949,13 +25949,13 @@
     },
     "packages/cli": {
       "name": "@hocuspocus/cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-sqlite": "^1.0.0",
-        "@hocuspocus/extension-webhook": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-sqlite": "^1.0.1",
+        "@hocuspocus/extension-webhook": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
         "meow": "^11.0.0"
       },
       "bin": {
@@ -26317,7 +26317,7 @@
     },
     "packages/common": {
       "name": "@hocuspocus/common",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.47"
@@ -26325,10 +26325,10 @@
     },
     "packages/extension-database": {
       "name": "@hocuspocus/extension-database",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       },
       "peerDependencies": {
         "yjs": "^13.5.29"
@@ -26336,18 +26336,18 @@
     },
     "packages/extension-logger": {
       "name": "@hocuspocus/extension-logger",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       }
     },
     "packages/extension-monitor": {
       "name": "@hocuspocus/extension-monitor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/server": "^1.0.1",
         "@types/node-os-utils": "^1.2.0",
         "bufferutil": "^4.0.6",
         "collect.js": "^4.32.0",
@@ -26581,10 +26581,10 @@
     },
     "packages/extension-redis": {
       "name": "@hocuspocus/extension-redis",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/server": "^1.0.1",
         "ioredis": "^4.28.2",
         "kleur": "^4.1.4",
         "lodash.debounce": "^4.0.8",
@@ -26611,10 +26611,10 @@
     },
     "packages/extension-sqlite": {
       "name": "@hocuspocus/extension-sqlite",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/extension-database": "^1.0.0",
+        "@hocuspocus/extension-database": "^1.0.1",
         "kleur": "^4.1.4",
         "sqlite3": "^5.0.11"
       },
@@ -26624,20 +26624,20 @@
     },
     "packages/extension-throttle": {
       "name": "@hocuspocus/extension-throttle",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       }
     },
     "packages/extension-webhook": {
       "name": "@hocuspocus/extension-webhook",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "axios": "^1.2.2"
       },
       "peerDependencies": {
@@ -26646,10 +26646,10 @@
     },
     "packages/provider": {
       "name": "@hocuspocus/provider",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
         "@lifeomic/attempt": "^3.0.2",
         "lib0": "^0.2.46"
       },
@@ -26660,10 +26660,10 @@
     },
     "packages/server": {
       "name": "@hocuspocus/server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
         "@types/async-lock": "^1.1.3",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.5.3",
@@ -26708,7 +26708,7 @@
     },
     "packages/transformer": {
       "name": "@hocuspocus/transformer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^2.0.0-beta.174",
@@ -26722,15 +26722,15 @@
     },
     "playground/backend": {
       "name": "@hocuspocus/server-demos",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-monitor": "^1.0.0",
-        "@hocuspocus/extension-redis": "^1.0.0",
-        "@hocuspocus/extension-sqlite": "^1.0.0",
-        "@hocuspocus/extension-webhook": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-monitor": "^1.0.1",
+        "@hocuspocus/extension-redis": "^1.0.1",
+        "@hocuspocus/extension-sqlite": "^1.0.1",
+        "@hocuspocus/extension-webhook": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "@tiptap/core": "^2.0.0-beta.174",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@types/express": "^4.17.13",
@@ -26750,9 +26750,9 @@
     },
     "playground/frontend": {
       "name": "@hocuspocus/provider-demos",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@hocuspocus/provider": "^1.0.0",
+        "@hocuspocus/provider": "^1.0.1",
         "@tiptap/extension-collaboration": "^2.0.0-beta.33",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@tiptap/vue-2": "^2.0.0-beta.77",
@@ -26942,14 +26942,14 @@
       }
     },
     "tests": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-redis": "^1.0.0",
-        "@hocuspocus/extension-throttle": "^1.0.0",
-        "@hocuspocus/provider": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-redis": "^1.0.1",
+        "@hocuspocus/extension-throttle": "^1.0.1",
+        "@hocuspocus/provider": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "node-fetch": "^3.2.3",
         "redis": "^4.0.4",
         "sinon": "^12.0.1",
@@ -28305,10 +28305,10 @@
     "@hocuspocus/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-sqlite": "^1.0.0",
-        "@hocuspocus/extension-webhook": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-sqlite": "^1.0.1",
+        "@hocuspocus/extension-webhook": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
         "meow": "^11.0.0"
       },
       "dependencies": {
@@ -28533,20 +28533,20 @@
     "@hocuspocus/extension-database": {
       "version": "file:packages/extension-database",
       "requires": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       }
     },
     "@hocuspocus/extension-logger": {
       "version": "file:packages/extension-logger",
       "requires": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       }
     },
     "@hocuspocus/extension-monitor": {
       "version": "file:packages/extension-monitor",
       "requires": {
         "@fullhuman/postcss-purgecss": "^5.0.0",
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/server": "^1.0.1",
         "@tailwindcss/postcss7-compat": "npm:@tailwindcss/postcss7-compat",
         "@types/node-os-utils": "^1.2.0",
         "@types/serve-handler": "^6.1.1",
@@ -28686,7 +28686,7 @@
     "@hocuspocus/extension-redis": {
       "version": "file:packages/extension-redis",
       "requires": {
-        "@hocuspocus/server": "^1.0.0",
+        "@hocuspocus/server": "^1.0.1",
         "@types/ioredis": "^4.28.7",
         "@types/lodash.debounce": "^4.0.6",
         "@types/redlock": "^4.0.3",
@@ -28707,7 +28707,7 @@
     "@hocuspocus/extension-sqlite": {
       "version": "file:packages/extension-sqlite",
       "requires": {
-        "@hocuspocus/extension-database": "^1.0.0",
+        "@hocuspocus/extension-database": "^1.0.1",
         "@types/sqlite3": "^3.1.8",
         "kleur": "^4.1.4",
         "sqlite3": "^5.0.11"
@@ -28716,22 +28716,22 @@
     "@hocuspocus/extension-throttle": {
       "version": "file:packages/extension-throttle",
       "requires": {
-        "@hocuspocus/server": "^1.0.0"
+        "@hocuspocus/server": "^1.0.1"
       }
     },
     "@hocuspocus/extension-webhook": {
       "version": "file:packages/extension-webhook",
       "requires": {
-        "@hocuspocus/common": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "axios": "^1.2.2"
       }
     },
     "@hocuspocus/provider": {
       "version": "file:packages/provider",
       "requires": {
-        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
         "@lifeomic/attempt": "^3.0.2",
         "lib0": "^0.2.46"
       }
@@ -28739,7 +28739,7 @@
     "@hocuspocus/provider-demos": {
       "version": "file:playground/frontend",
       "requires": {
-        "@hocuspocus/provider": "^1.0.0",
+        "@hocuspocus/provider": "^1.0.1",
         "@tiptap/extension-collaboration": "^2.0.0-beta.33",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@tiptap/vue-2": "^2.0.0-beta.77",
@@ -28860,7 +28860,7 @@
     "@hocuspocus/server": {
       "version": "file:packages/server",
       "requires": {
-        "@hocuspocus/common": "^1.0.0",
+        "@hocuspocus/common": "^1.0.1",
         "@types/async-lock": "^1.1.3",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.5.3",
@@ -28887,13 +28887,13 @@
     "@hocuspocus/server-demos": {
       "version": "file:playground/backend",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-monitor": "^1.0.0",
-        "@hocuspocus/extension-redis": "^1.0.0",
-        "@hocuspocus/extension-sqlite": "^1.0.0",
-        "@hocuspocus/extension-webhook": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-monitor": "^1.0.1",
+        "@hocuspocus/extension-redis": "^1.0.1",
+        "@hocuspocus/extension-sqlite": "^1.0.1",
+        "@hocuspocus/extension-webhook": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "@tiptap/core": "^2.0.0-beta.174",
         "@tiptap/starter-kit": "^2.0.0-beta.183",
         "@types/express": "^4.17.13",
@@ -45170,12 +45170,12 @@
     "tests": {
       "version": "file:tests",
       "requires": {
-        "@hocuspocus/extension-logger": "^1.0.0",
-        "@hocuspocus/extension-redis": "^1.0.0",
-        "@hocuspocus/extension-throttle": "^1.0.0",
-        "@hocuspocus/provider": "^1.0.0",
-        "@hocuspocus/server": "^1.0.0",
-        "@hocuspocus/transformer": "^1.0.0",
+        "@hocuspocus/extension-logger": "^1.0.1",
+        "@hocuspocus/extension-redis": "^1.0.1",
+        "@hocuspocus/extension-throttle": "^1.0.1",
+        "@hocuspocus/provider": "^1.0.1",
+        "@hocuspocus/server": "^1.0.1",
+        "@hocuspocus/transformer": "^1.0.1",
         "@types/redis": "^4.0.11",
         "@types/sinon": "^10.0.11",
         "lib0": "^0.2.47",


### PR DESCRIPTION
I think `npm i` wasn't run after https://github.com/ueberdosis/hocuspocus/commit/cb21edca148bb63fcd890e594d789637f65712c0, causing the lockfile to become desynchronized/outdated.