### PR TITLE
feature: send stateless messages over the existing websocket connection

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -27,6 +27,7 @@ If a user isn’t allowed to connect: Just send `reject()` in the `onConnect()` 
 | `onRequest`           | When a HTTP request comes in              | [Read more](/api/hooks/on-request)            |
 | `onStoreDocument`     | When a document has been changed          | [Read more](/api/hooks/on-store-document)     |
 | `onUpgrade`           | When the WebSocket connection is upgraded | [Read more](/api/hooks/on-upgrade)            |
+| `onStateless`         | When the Stateless message is received    | [Read more](/api/hooks/on-stateless)          |
 
 ## Usage
 

--- a/docs/api/hooks/on-stateless.md
+++ b/docs/api/hooks/on-stateless.md
@@ -6,7 +6,7 @@ tableOfContents: true
 
 ## Introduction
 
-The `onStateless` hook is called after the server is received a stateless message. It should return a Promise.
+The `onStateless` hook is called after the server has received a stateless message. It should return a Promise.
 
 ## Hook payload
 
@@ -29,7 +29,7 @@ import { Server } from '@hocuspocus/server'
 const server = Server.configure({
   async onStateless(data) {
     // Output some information
-    console.log(`Server is received a stateless message "${data.payload}"!`)
+    console.log(`Server has received a stateless message "${data.payload}"!`)
   },
 })
 

--- a/docs/api/hooks/on-stateless.md
+++ b/docs/api/hooks/on-stateless.md
@@ -27,9 +27,13 @@ const data = {
 import { Server } from '@hocuspocus/server'
 
 const server = Server.configure({
-  async onStateless(data) {
+  async onStateless({ payload, document, connection }) {
     // Output some information
-    console.log(`Server has received a stateless message "${data.payload}"!`)
+    console.log(`Server has received a stateless message "${payload}"!`)
+    // Broadcast a stateless message to all connections based on document
+    document.sendStateless('This is a broadcast message.')
+    // Send a stateless message to a specific connection
+    connection.sendStateless('This is a specific message.')
   },
 })
 

--- a/docs/api/hooks/on-stateless.md
+++ b/docs/api/hooks/on-stateless.md
@@ -1,0 +1,37 @@
+---
+tableOfContents: true
+---
+
+# onStateless
+
+## Introduction
+
+The `onStateless` hook is called after the server is received a stateless message. It should return a Promise.
+
+## Hook payload
+
+The `data` passed to the `onListen` hook has the following attributes:
+
+```js
+const data = {
+  connection: Connection,
+  documentName: string,
+  document: Document,
+  payload: string,
+}
+```
+
+## Example
+
+```js
+import { Server } from '@hocuspocus/server'
+
+const server = Server.configure({
+  async onStateless(data) {
+    // Output some information
+    console.log(`Server is received a stateless message "${data.payload}"!`)
+  },
+})
+
+server.listen()
+```

--- a/docs/api/hooks/on-stateless.md
+++ b/docs/api/hooks/on-stateless.md
@@ -31,7 +31,7 @@ const server = Server.configure({
     // Output some information
     console.log(`Server has received a stateless message "${payload}"!`)
     // Broadcast a stateless message to all connections based on document
-    document.sendStateless('This is a broadcast message.')
+    document.broadcastStateless('This is a broadcast message.')
     // Send a stateless message to a specific connection
     connection.sendStateless('This is a specific message.')
   },

--- a/docs/provider/events.md
+++ b/docs/provider/events.md
@@ -54,6 +54,9 @@ const provider = new HocuspocusProvider({
   onAwarenessChange: ({ states }) => {
     // …
   },
+  onStateless: ({ payload }) => {
+    // ...
+  }
 })
 ```
 
@@ -103,3 +106,4 @@ provider.off('onMessage', onMessage)
 | destroy              | When the provider will be destroyed.                                       |
 | awarenessUpdate      | When the awareness updates  (see https://docs.yjs.dev/api/about-awareness) |
 | awarenessChange      | When the awareness changes  (see https://docs.yjs.dev/api/about-awareness) |
+| stateless            | When the stateless message was received.                                   |

--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -5,6 +5,7 @@ import { MessageType } from './types'
 import { HocuspocusProvider } from './HocuspocusProvider'
 import { IncomingMessage } from './IncomingMessage'
 import { OutgoingMessage } from './OutgoingMessage'
+import { readVarString } from 'lib0/decoding'
 
 export class MessageReceiver {
 
@@ -42,6 +43,10 @@ export class MessageReceiver {
       case MessageType.QueryAwareness:
         this.applyQueryAwarenessMessage(provider)
         break
+
+        case MessageType.Stateless:
+          provider.receiveStateless(readVarString(message.decoder))
+          break
 
       default:
         throw new Error(`Can’t apply message of unknown type: ${type}`)

--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -1,11 +1,11 @@
 import * as awarenessProtocol from 'y-protocols/awareness'
 import { readSyncMessage, messageYjsSyncStep2, messageYjsUpdate } from 'y-protocols/sync'
 import { readAuthMessage } from '@hocuspocus/common'
+import { readVarString } from 'lib0/decoding'
 import { MessageType } from './types'
 import { HocuspocusProvider } from './HocuspocusProvider'
 import { IncomingMessage } from './IncomingMessage'
 import { OutgoingMessage } from './OutgoingMessage'
-import { readVarString } from 'lib0/decoding'
 
 export class MessageReceiver {
 
@@ -44,9 +44,9 @@ export class MessageReceiver {
         this.applyQueryAwarenessMessage(provider)
         break
 
-        case MessageType.Stateless:
-          provider.receiveStateless(readVarString(message.decoder))
-          break
+      case MessageType.Stateless:
+        provider.receiveStateless(readVarString(message.decoder))
+        break
 
       default:
         throw new Error(`Can’t apply message of unknown type: ${type}`)

--- a/packages/provider/src/OutgoingMessages/StatelessMessage.ts
+++ b/packages/provider/src/OutgoingMessages/StatelessMessage.ts
@@ -1,0 +1,16 @@
+import { writeVarString, writeVarUint } from 'lib0/encoding'
+import { MessageType, OutgoingMessageArguments } from '../types'
+import { OutgoingMessage } from '../OutgoingMessage'
+
+export class StatelessMessage extends OutgoingMessage {
+  type = MessageType.Stateless
+
+  description = 'A stateless message'
+
+  get(args: Partial<OutgoingMessageArguments>) {
+    writeVarUint(this.encoder, this.type)
+    writeVarString(this.encoder, args.payload ?? '')
+
+    return this.encoder
+  }
+}

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -16,6 +16,7 @@ export enum MessageType {
   Awareness = 1,
   Auth = 2,
   QueryAwareness = 3,
+  Stateless = 5,
 }
 
 export enum WebSocketStatus {
@@ -36,6 +37,7 @@ export interface OutgoingMessageArguments {
   clients: number[],
   states: Map<number, { [key: string]: any; }>,
   update: any,
+  payload: string,
   encoder: Encoder,
 }
 
@@ -90,6 +92,10 @@ export type onAwarenessUpdateParameters = {
 
 export type onAwarenessChangeParameters = {
   states: StatesArray
+}
+
+export type onStatelessParameters = {
+  payload: string
 }
 
 export type StatesArray = { clientId: number, [key: string | number]: any }[]

--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -30,7 +30,7 @@ export class Connection {
   callbacks: any = {
     onClose: (document: Document) => null,
     beforeHandleMessage: (document: Document, update: Uint8Array) => Promise,
-    statelessCallback: ({}) => Promise,
+    statelessCallback: () => Promise,
   }
 
   socketId: string
@@ -123,7 +123,6 @@ export class Connection {
       this.close()
     }
   }
-
 
   public sendStateless(payload: string): void {
     const message = new OutgoingMessage()

--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -124,6 +124,9 @@ export class Connection {
     }
   }
 
+  /**
+   * Send a stateless message with payload
+   */
   public sendStateless(payload: string): void {
     const message = new OutgoingMessage()
       .writeStateless(payload)

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -215,6 +215,15 @@ export class Document extends Doc {
 
     return this
   }
+
+  /**
+   * Broadcast stateless message to all connections
+   */
+  public sendStateless(payload: string): void {
+    this.getConnections().forEach(connection => {
+      connection.sendStateless(payload)
+    })
+  }
 }
 
 export default Document

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -219,7 +219,7 @@ export class Document extends Doc {
   /**
    * Broadcast stateless message to all connections
    */
-  public sendStateless(payload: string): void {
+  public broadcastStateless(payload: string): void {
     this.getConnections().forEach(connection => {
       connection.sendStateless(payload)
     })

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -19,7 +19,8 @@ import {
   ConnectionConfiguration,
   HookName,
   AwarenessUpdate,
-  HookPayload, beforeHandleMessagePayload,
+  HookPayload, 
+  beforeHandleMessagePayload,
 } from './types'
 import Document from './Document'
 import Connection from './Connection'
@@ -55,6 +56,7 @@ export class Hocuspocus {
     onConnect: () => new Promise(r => r(null)),
     connected: () => new Promise(r => r(null)),
     beforeHandleMessage: () => new Promise(r => r(null)),
+    onStateless: () => new Promise(r => r(null)),
     onChange: () => new Promise(r => r(null)),
     onLoadDocument: () => new Promise(r => r(null)),
     onStoreDocument: () => new Promise(r => r(null)),
@@ -112,6 +114,7 @@ export class Hocuspocus {
       onAuthenticate: this.configuration.onAuthenticate,
       onLoadDocument: this.configuration.onLoadDocument,
       beforeHandleMessage: this.configuration.beforeHandleMessage,
+      onStateless: this.configuration.onStateless,
       onChange: this.configuration.onChange,
       onStoreDocument: this.configuration.onStoreDocument,
       afterStoreDocument: this.configuration.afterStoreDocument,
@@ -723,6 +726,16 @@ export class Hocuspocus {
       this.documents.delete(document.name)
       document.destroy()
     })
+
+    instance.onStatelessCallback(payload => {
+      return this.hooks('onStateless', payload)
+        .catch(error => {
+          if (error?.message) {
+            throw error
+          }
+        })
+    })
+
     instance.beforeHandleMessage((document, update) => {
       const hookPayload: beforeHandleMessagePayload = {
         instance: this,

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -19,7 +19,7 @@ import {
   ConnectionConfiguration,
   HookName,
   AwarenessUpdate,
-  HookPayload, 
+  HookPayload,
   beforeHandleMessagePayload,
 } from './types'
 import Document from './Document'

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -13,6 +13,7 @@ import { IncomingMessage } from './IncomingMessage'
 import { OutgoingMessage } from './OutgoingMessage'
 import { Debugger } from './Debugger'
 import Document from './Document'
+import { readVarString } from 'lib0/decoding'
 
 export class MessageReceiver {
 
@@ -65,6 +66,18 @@ export class MessageReceiver {
         this.applyQueryAwarenessMessage(document.awareness, reply)
 
         break
+
+      case MessageType.Stateless:
+
+        connection?.callbacks.statelessCallback({
+          connection,
+          documentName: document.name,
+          document,
+          payload: readVarString(message.decoder),
+        })
+
+        break
+
       default:
         // Do nothing
     }

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -7,13 +7,13 @@ import {
   readUpdate,
 } from 'y-protocols/sync'
 import { applyAwarenessUpdate, Awareness } from 'y-protocols/awareness'
+import { readVarString } from 'lib0/decoding'
 import { MessageType } from './types'
 import Connection from './Connection'
 import { IncomingMessage } from './IncomingMessage'
 import { OutgoingMessage } from './OutgoingMessage'
 import { Debugger } from './Debugger'
 import Document from './Document'
-import { readVarString } from 'lib0/decoding'
 
 export class MessageReceiver {
 

--- a/packages/server/src/OutgoingMessage.ts
+++ b/packages/server/src/OutgoingMessage.ts
@@ -2,6 +2,7 @@ import {
   createEncoder,
   Encoder,
   toUint8Array,
+  writeVarString,
   writeVarUint,
   writeVarUint8Array,
 } from 'lib0/encoding'
@@ -96,6 +97,15 @@ export class OutgoingMessage {
     this.category = 'Update'
 
     writeUpdate(this.encoder, update)
+
+    return this
+  }
+
+  writeStateless(payload: string): OutgoingMessage {
+    this.category = 'Stateless'
+
+    writeVarUint(this.encoder, MessageType.Stateless)
+    writeVarString(this.encoder, payload)
 
     return this
   }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -6,6 +6,7 @@ import { Socket } from 'net'
 import { Awareness } from 'y-protocols/awareness'
 import Document from './Document'
 import { Hocuspocus } from './Hocuspocus'
+import Connection from './Connection'
 
 export enum MessageType {
   Unknown = -1,
@@ -14,6 +15,7 @@ export enum MessageType {
   Auth = 2,
   QueryAwareness = 3,
   SyncReply = 4, // same as Sync, but won't trigger another 'SyncStep1'
+  Stateless = 5,
 }
 
 export interface AwarenessUpdate {
@@ -39,6 +41,7 @@ export interface Extension {
   onLoadDocument?(data: onLoadDocumentPayload): Promise<any>,
   afterLoadDocument?(data: onLoadDocumentPayload): Promise<any>,
   beforeHandleMessage?(data: beforeHandleMessagePayload): Promise<any>,
+  onStateless?(payload: onStatelessPayload): Promise<any>;
   onChange?(data: onChangePayload): Promise<any>,
   onStoreDocument?(data: onStoreDocumentPayload): Promise<any>,
   afterStoreDocument?(data: afterStoreDocumentPayload): Promise<any>,
@@ -58,6 +61,7 @@ export type HookName =
   'onLoadDocument' |
   'afterLoadDocument' |
   'beforeHandleMessage' |
+  'onStateless' |
   'onChange' |
   'onStoreDocument' |
   'afterStoreDocument' |
@@ -74,6 +78,7 @@ export type HookPayload =
   connectedPayload |
   onAuthenticatePayload |
   onLoadDocumentPayload |
+  onStatelessPayload |
   onChangePayload |
   onStoreDocumentPayload |
   afterStoreDocumentPayload |
@@ -134,6 +139,13 @@ export interface getDocumentNamePayload {
   documentName: string,
   request: IncomingMessage,
   requestParameters: URLSearchParams,
+}
+
+export interface onStatelessPayload {
+  connection: Connection,
+  documentName: string,
+  document: Document,
+  payload: string,
 }
 
 export interface onAuthenticatePayload {

--- a/tests/provider/onStateless.ts
+++ b/tests/provider/onStateless.ts
@@ -14,7 +14,7 @@ test('executes the onStateless callback', async t => {
       const provider = newHocuspocusProvider(server, {
         onSynced: () => {
           provider.sendStateless(payloadToSend)
-        }
+        },
       })
     })
   })

--- a/tests/provider/onStateless.ts
+++ b/tests/provider/onStateless.ts
@@ -1,0 +1,21 @@
+import test from 'ava'
+import { newHocuspocus, newHocuspocusProvider } from '../utils'
+
+test('executes the onStateless callback', async t => {
+  const payloadToSend = 'STATELESS-MESSAGE'
+  await new Promise(async resolve => {
+    newHocuspocus({
+      async onStateless({ payload }) {
+        t.is(payload, payloadToSend)
+        t.pass()
+        resolve('done')
+      },
+    }).then(server => {
+      const provider = newHocuspocusProvider(server, {
+        onSynced: () => {
+          provider.sendStateless(payloadToSend)
+        }
+      })
+    })
+  })
+})

--- a/tests/server/onStateless.ts
+++ b/tests/server/onStateless.ts
@@ -7,7 +7,7 @@ test('broadcast stateless message to all connections', async t => {
     const payloadToSend = 'STATELESS-MESSAGE'
     const server = await newHocuspocus({
       onStateless: async ({ document }) => {
-        await document.sendStateless(payloadToSend)
+        await document.broadcastStateless(payloadToSend)
       },
     })
 
@@ -89,7 +89,7 @@ test('the server actively sends a stateless message', async t => {
   await new Promise(resolve => {
     newHocuspocusProvider(server, {
       onSynced: async () => {
-        server.documents.get('hocuspocus-test')?.sendStateless(payloadToSend)
+        server.documents.get('hocuspocus-test')?.broadcastStateless(payloadToSend)
       },
       onStateless: async ({ payload }) => {
         t.is(payload, payloadToSend)

--- a/tests/server/onStateless.ts
+++ b/tests/server/onStateless.ts
@@ -1,30 +1,31 @@
-import test from "ava";
-import { newHocuspocus, newHocuspocusProvider } from "../utils";
+import test from 'ava'
+import { newHocuspocus, newHocuspocusProvider } from '../utils'
 
-test("broadcast stateless message to all connections", async (t) => {
-  await new Promise(async (resolve) => {
-    const payloadToSend = "STATELESS-MESSAGE";
+test('broadcast stateless message to all connections', async t => {
+  await new Promise(async resolve => {
+    const payloadToSend = 'STATELESS-MESSAGE'
     const server = await newHocuspocus({
-      onStateless: async ({ document, connection }) => {
-        await document.sendStateless(payloadToSend);
+      onStateless: async ({ document }) => {
+        await document.sendStateless(payloadToSend)
       },
-    });
+    })
 
-    let count = 2;
+    let count = 2
     const onStatelessCallback = (payload: string) => {
-      t.is(payload, payloadToSend);
-      if (--count === 0) {
-        t.pass();
-        resolve("done");
+      t.is(payload, payloadToSend)
+      count -= 1
+      if (count === 0) {
+        t.pass()
+        resolve('done')
       }
-    };
+    }
 
-    newHocuspocusProvider(server, { onStateless: ({ payload }) => onStatelessCallback(payload) });
+    newHocuspocusProvider(server, { onStateless: ({ payload }) => onStatelessCallback(payload) })
     const provider = newHocuspocusProvider(server, {
       onStateless: ({ payload }) => onStatelessCallback(payload),
       onSynced: () => {
-        provider.sendStateless(payloadToSend);
+        provider.sendStateless(payloadToSend)
       },
-    });
-  });
-});
+    })
+  })
+})

--- a/tests/server/onStateless.ts
+++ b/tests/server/onStateless.ts
@@ -1,0 +1,30 @@
+import test from "ava";
+import { newHocuspocus, newHocuspocusProvider } from "../utils";
+
+test("broadcast stateless message to all connections", async (t) => {
+  await new Promise(async (resolve) => {
+    const payloadToSend = "STATELESS-MESSAGE";
+    const server = await newHocuspocus({
+      onStateless: async ({ document, connection }) => {
+        await document.sendStateless(payloadToSend);
+      },
+    });
+
+    let count = 2;
+    const onStatelessCallback = (payload: string) => {
+      t.is(payload, payloadToSend);
+      if (--count === 0) {
+        t.pass();
+        resolve("done");
+      }
+    };
+
+    newHocuspocusProvider(server, { onStateless: ({ payload }) => onStatelessCallback(payload) });
+    const provider = newHocuspocusProvider(server, {
+      onStateless: ({ payload }) => onStatelessCallback(payload),
+      onSynced: () => {
+        provider.sendStateless(payloadToSend);
+      },
+    });
+  });
+});

--- a/tests/server/onStateless.ts
+++ b/tests/server/onStateless.ts
@@ -1,4 +1,5 @@
 import test from 'ava'
+import { onStatelessPayload } from '@hocuspocus/server'
 import { newHocuspocus, newHocuspocusProvider } from '../utils'
 
 test('broadcast stateless message to all connections', async t => {
@@ -25,6 +26,75 @@ test('broadcast stateless message to all connections', async t => {
       onStateless: ({ payload }) => onStatelessCallback(payload),
       onSynced: () => {
         provider.sendStateless(payloadToSend)
+      },
+    })
+  })
+})
+
+test('send a stateless message to a specific connection', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      onStateless: async ({ connection }: onStatelessPayload) => {
+        connection.sendStateless('This is a specific message.')
+      },
+    })
+
+    await newHocuspocusProvider(server, {
+      onStateless: async () => {
+        throw Error('The provider1 should not receive messages')
+      },
+    })
+
+    const provider = await newHocuspocusProvider(server, {
+      onSynced: () => {
+        provider.sendStateless('Send stateless message, and then a stateless message is will be received')
+      },
+      onStateless: () => {
+        t.pass()
+        resolve('done')
+      },
+    })
+  })
+})
+
+test('calls the onStateless hook', async t => {
+  await new Promise(async resolve => {
+    const payloadToSend = 'STATELESS-MESSAGE'
+    class CustomExtension {
+      async onStateless({ payload }: onStatelessPayload) {
+        t.is(payload, payloadToSend)
+        t.pass()
+        resolve('done')
+      }
+    }
+
+    const server = await newHocuspocus({
+      extensions: [
+        new CustomExtension(),
+      ],
+    })
+
+    const provider = await newHocuspocusProvider(server, {
+      onSynced: async () => {
+        provider.sendStateless(payloadToSend)
+      },
+    })
+  })
+})
+
+test('the server actively sends a stateless message', async t => {
+  const payloadToSend = 'STATELESS-MESSAGE'
+  const server = await newHocuspocus()
+
+  await new Promise(resolve => {
+    newHocuspocusProvider(server, {
+      onSynced: async () => {
+        server.documents.get('hocuspocus-test')?.sendStateless(payloadToSend)
+      },
+      onStateless: async ({ payload }) => {
+        t.is(payload, payloadToSend)
+        t.pass()
+        resolve('done')
       },
     })
   })


### PR DESCRIPTION
# Changes

-   Adds a new MessageType [Stateless]
	- The provider and server can send stateless messages to each other
	- The server can broadcast stateless messages to all connections based on document
-   Adds tests for the stateless message

# Context

Addresses [#148](https://github.com/ueberdosis/hocuspocus/issues/279)