### PR TITLE
Add missing update field to onStoreDocumentPayload

### DIFF
--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -220,6 +220,7 @@ export interface onStoreDocumentPayload {
   instance: Hocuspocus,
   requestHeaders: IncomingHttpHeaders,
   requestParameters: URLSearchParams,
+  update: Uint8Array,
   socketId: string,
 }
 


### PR DESCRIPTION
Noticed that `update` was missing from the `onStoreDocumentPayload` interface. 

The documentation regarding the payload states that the update should be a part of the payload:
https://github.com/ueberdosis/hocuspocus/blob/main/docs/api/hooks/on-store-document.md

We can also see that the update is included in the payload from `handleDocumentUpdate`
https://github.com/ueberdosis/hocuspocus/blob/main/packages/server/src/Hocuspocus.ts#L530-L555