### PR TITLE
removes "update" field from onStoreDocument hook documentation. It is…

### DIFF
--- a/docs/api/hooks/on-store-document.md
+++ b/docs/api/hooks/on-store-document.md
@@ -31,7 +31,6 @@ const data = {
   instance: Hocuspocus,
   requestHeaders: IncomingHttpHeaders,
   requestParameters: URLSearchParams,
-  update: Uint8Array,
   socketId: string,
 }
 ```


### PR DESCRIPTION
… misleading as changes are debounced, so the update may not be what is expected, refs #521