### PR TITLE
Fixes #530: Pass connection to beforeHandleMessage

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -29,7 +29,7 @@ export class Connection {
 
   callbacks: any = {
     onClose: [(document: Document, event?: CloseEvent) => null],
-    beforeHandleMessage: (document: Document, update: Uint8Array) => Promise,
+    beforeHandleMessage: (connection: Connection, update: Uint8Array) => Promise,
     statelessCallback: () => Promise,
   }
 
@@ -108,7 +108,7 @@ export class Connection {
   /**
    * Set a callback that will be triggered before an message is handled
    */
-  beforeHandleMessage(callback: (payload: Document, update: Uint8Array) => Promise<any>): Connection {
+  beforeHandleMessage(callback: (connection: Connection, update: Uint8Array) => Promise<any>): Connection {
     this.callbacks.beforeHandleMessage = callback
 
     return this
@@ -229,7 +229,7 @@ export class Connection {
 
     message.writeVarString(documentName)
 
-    this.callbacks.beforeHandleMessage(this.document, data)
+    this.callbacks.beforeHandleMessage(this, data)
       .then(() => {
         new MessageReceiver(
           message,

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -791,13 +791,14 @@ export class Hocuspocus {
         })
     })
 
-    instance.beforeHandleMessage((document, update) => {
+    instance.beforeHandleMessage((connection, update) => {
       const hookPayload: beforeHandleMessagePayload = {
         instance: this,
         clientsCount: document.getConnectionsCount(),
         context,
         document,
         socketId,
+        connection,
         documentName: document.name,
         requestHeaders: request.headers,
         requestParameters: Hocuspocus.getParameters(request),

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -228,6 +228,7 @@ export interface beforeHandleMessagePayload {
   requestParameters: URLSearchParams,
   update: Uint8Array,
   socketId: string,
+  connection: Connection
 }
 
 export interface beforeBroadcastStatelessPayload {


### PR DESCRIPTION
Passes `connection` to beforeHandleMessage hooks