### PR TITLE
server can't get parameters.

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -213,7 +213,7 @@ export class HocuspocusProvider extends EventEmitter {
 
   public setConfiguration(configuration: Partial<HocuspocusProviderConfiguration> = {}): void {
     if (!configuration.websocketProvider && (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url) {
-      this.configuration.websocketProvider = new HocuspocusProviderWebsocket({ url: (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url })
+      this.configuration.websocketProvider = new HocuspocusProviderWebsocket({ url: (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url, parameters: (configuration as CompleteHocuspocusProviderConfiguration).parameters })
     }
 
     this.configuration = { ...this.configuration, ...configuration }

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -213,7 +213,7 @@ export class HocuspocusProvider extends EventEmitter {
 
   public setConfiguration(configuration: Partial<HocuspocusProviderConfiguration> = {}): void {
     if (!configuration.websocketProvider && (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url) {
-      this.configuration.websocketProvider = new HocuspocusProviderWebsocket({ url: (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url, parameters: (configuration as CompleteHocuspocusProviderConfiguration).parameters })
+      this.configuration.websocketProvider = new HocuspocusProviderWebsocket({ url: (configuration as CompleteHocuspocusProviderWebsocketConfiguration).url, parameters: (configuration as CompleteHocuspocusProviderWebsocketConfiguration).parameters })
     }
 
     this.configuration = { ...this.configuration, ...configuration }


### PR DESCRIPTION
If the `HocuspocusProvider` does not provide a `websocketProvider`, the `parameters` of the `HocuspocusProvider` are not available to the server.