### PR TITLE
fix: export typings for recent typescript

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-common.esm.js",
-      "require": "./dist/hocuspocus-common.cjs"
+      "require": "./dist/hocuspocus-common.cjs",
+      "types": "./dist/packages/common/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-database/package.json
+++ b/packages/extension-database/package.json
@@ -18,7 +18,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-database.esm.js",
-      "require": "./dist/hocuspocus-database.cjs"
+      "require": "./dist/hocuspocus-database.cjs",
+      "types": "./dist/packages/database/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-logger/package.json
+++ b/packages/extension-logger/package.json
@@ -20,7 +20,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-logger.esm.js",
-      "require": "./dist/hocuspocus-logger.cjs"
+      "require": "./dist/hocuspocus-logger.cjs",
+      "types": "./dist/packages/logger/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-redis/package.json
+++ b/packages/extension-redis/package.json
@@ -19,7 +19,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-redis.esm.js",
-      "require": "./dist/hocuspocus-redis.cjs"
+      "require": "./dist/hocuspocus-redis.cjs",
+      "types": "./dist/packages/redis/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-sqlite/package.json
+++ b/packages/extension-sqlite/package.json
@@ -18,7 +18,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-sqlite.esm.js",
-      "require": "./dist/hocuspocus-sqlite.cjs"
+      "require": "./dist/hocuspocus-sqlite.cjs",
+      "types": "./dist/packages/sqlite/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-throttle/package.json
+++ b/packages/extension-throttle/package.json
@@ -19,7 +19,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-throttle.esm.js",
-      "require": "./dist/hocuspocus-throttle.cjs"
+      "require": "./dist/hocuspocus-throttle.cjs",
+      "types": "./dist/packages/throttle/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/extension-webhook/package.json
+++ b/packages/extension-webhook/package.json
@@ -21,7 +21,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-webhook.esm.js",
-      "require": "./dist/hocuspocus-webhook.cjs"
+      "require": "./dist/hocuspocus-webhook.cjs",
+      "types": "./dist/packages/webhook/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-provider.esm.js",
-      "require": "./dist/hocuspocus-provider.cjs"
+      "require": "./dist/hocuspocus-provider.cjs",
+      "types": "./dist/packages/provider/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-server.esm.js",
-      "require": "./dist/hocuspocus-server.cjs"
+      "require": "./dist/hocuspocus-server.cjs",
+      "types": "./dist/packages/server/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -19,7 +19,8 @@
     },
     "default": {
       "import": "./dist/hocuspocus-transformer.esm.js",
-      "require": "./dist/hocuspocus-transformer.cjs"
+      "require": "./dist/hocuspocus-transformer.cjs",
+      "types": "./dist/packages/transformer/src/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Related to TS5 module resolution (nodenext, bundler…)

<img width="964" alt="Screenshot 2023-05-10 at 17 23 45" src="https://github.com/ueberdosis/hocuspocus/assets/603498/98e2e958-e9ff-456c-a7bb-cd736b47a628">

It seems like a common plague since 5.0 dropped.

E.g. https://github.com/artalar/reatom/issues/560#issuecomment-1528997739