### PR TITLE
Add connection and context to `connected` hook payload

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -436,7 +436,12 @@ export class Hocuspocus {
         incoming.emit('message', input)
       })
 
-      this.hooks('connected', { ...hookPayload, documentName })
+      this.hooks('connected', {
+        ...hookPayload,
+        documentName,
+        context,
+        connectionInstance: instance,
+      })
     }
 
     // This listener handles authentication messages and queues everything else.

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -154,6 +154,8 @@ export interface onStatelessPayload {
   payload: string,
 }
 
+// @todo Change 'connection' to 'connectionConfig' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface onAuthenticatePayload {
   documentName: string,
   instance: Hocuspocus,
@@ -164,6 +166,8 @@ export interface onAuthenticatePayload {
   connection: ConnectionConfiguration
 }
 
+// @todo Change 'connection' to 'connectionConfig' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface onConnectPayload {
   documentName: string,
   instance: Hocuspocus,
@@ -174,16 +178,22 @@ export interface onConnectPayload {
   connection: ConnectionConfiguration
 }
 
+// @todo Change 'connection' to 'connectionConfig', and 'connectionInstance' to 'connection' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface connectedPayload {
+  context: any,
   documentName: string,
   instance: Hocuspocus,
   request: IncomingMessage,
   requestHeaders: IncomingHttpHeaders,
   requestParameters: URLSearchParams,
   socketId: string,
-  connection: ConnectionConfiguration
+  connection: ConnectionConfiguration,
+  connectionInstance: Connection
 }
 
+// @todo Change 'connection' to 'connectionConfig' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface onLoadDocumentPayload {
   context: any,
   document: Document,
@@ -195,6 +205,8 @@ export interface onLoadDocumentPayload {
   connection: ConnectionConfiguration
 }
 
+// @todo Change 'connection' to 'connectionConfig' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface afterLoadDocumentPayload {
   context: any,
   document: Document,
@@ -269,6 +281,8 @@ export interface onAwarenessUpdatePayload {
 
 export type StatesArray = { clientId: number, [key: string | number]: any }[]
 
+// @todo Change 'connection' to 'connectionConfig' in next major release
+// see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface fetchPayload {
   context: any,
   document: Document,


### PR DESCRIPTION
Adds `connection` and `context` to the `connectedPayload` type for the `connected` hook.

Because `connectedPayload` already has `connection` (`ConnectionConfiguration`), if this PR intention is acceptable, we have the choice of either:

(a) make the most sensible change, but require a breaking change (i.e. bump the major version)
(b) make the least disruptive change, but add a key that could be a little confusing / misdirecting

This PR currently applies choice (a), but it could easily be switched. See #606.