### PR TITLE
Add direct connections to documents

### DIFF
--- a/packages/server/src/DirectConnection.ts
+++ b/packages/server/src/DirectConnection.ts
@@ -1,0 +1,53 @@
+import { URLSearchParams } from 'url'
+import Document from './Document'
+import type { Hocuspocus } from './Hocuspocus'
+
+export class DirectConnection {
+  documentPromise: Promise<Document> | null = null
+
+  instance!: Hocuspocus
+
+  context: any
+
+  document?: Document
+
+  /**
+   * Constructor.
+   */
+  constructor(
+    documentPromise: Promise<Document>,
+    instance: Hocuspocus,
+    context?: any,
+  ) {
+    this.documentPromise = documentPromise
+    this.instance = instance
+    this.context = context
+  }
+
+  async transact(transaction: (document: Document) => void) {
+    if (!this.documentPromise) {
+      throw new Error('direct connection closed')
+    }
+
+    this.document = await this.documentPromise
+    this.document.addDirectConnection()
+
+    transaction(this.document)
+
+    this.instance.storeDocumentHooks(this.document, {
+      clientsCount: this.document.getConnectionsCount(),
+      context: this.context,
+      document: this.document,
+      documentName: this.document.name,
+      instance: this.instance,
+      requestHeaders: {},
+      requestParameters: new URLSearchParams(),
+      socketId: 'server',
+    })
+  }
+
+  close() {
+    this.document?.removeDirectConnection()
+    this.documentPromise = null
+  }
+}

--- a/packages/server/src/DirectConnection.ts
+++ b/packages/server/src/DirectConnection.ts
@@ -3,34 +3,31 @@ import Document from './Document'
 import type { Hocuspocus } from './Hocuspocus'
 
 export class DirectConnection {
-  documentPromise: Promise<Document> | null = null
+  document: Document | null = null
 
   instance!: Hocuspocus
 
   context: any
 
-  document?: Document
-
   /**
    * Constructor.
    */
   constructor(
-    documentPromise: Promise<Document>,
+    document: Document,
     instance: Hocuspocus,
     context?: any,
   ) {
-    this.documentPromise = documentPromise
+    this.document = document
     this.instance = instance
     this.context = context
+
+    this.document.addDirectConnection()
   }
 
   async transact(transaction: (document: Document) => void) {
-    if (!this.documentPromise) {
+    if (!this.document) {
       throw new Error('direct connection closed')
     }
-
-    this.document = await this.documentPromise
-    this.document.addDirectConnection()
 
     transaction(this.document)
 
@@ -46,8 +43,8 @@ export class DirectConnection {
     })
   }
 
-  close() {
+  disconnect() {
     this.document?.removeDirectConnection()
-    this.documentPromise = null
+    this.document = null
   }
 }

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -22,6 +22,9 @@ export class Document extends Doc {
     connection: Connection
   }> = new Map()
 
+  // The number of direct (non-websocket) connections to this document
+  directConnectionsCount = 0
+
   name: string
 
   mux: mutex
@@ -121,11 +124,25 @@ export class Document extends Doc {
     return this
   }
 
+  addDirectConnection(): Document {
+    this.directConnectionsCount += 1
+
+    return this
+  }
+
+  removeDirectConnection(): Document {
+    if (this.directConnectionsCount > 0) {
+      this.directConnectionsCount -= 1
+    }
+
+    return this
+  }
+
   /**
    * Get the number of active connections for this document
    */
   getConnectionsCount(): number {
-    return this.connections.size
+    return this.connections.size + this.directConnectionsCount
   }
 
   /**

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -915,7 +915,7 @@ export class Hocuspocus {
     return this.debugger.get()?.logs
   }
 
-  async getDirectConnection({ documentName, context }: { documentName: string, context?: any }): Promise<DirectConnection> {
+  async openDirectConnection(documentName: string, context?: any): Promise<DirectConnection> {
     const connectionConfig: ConnectionConfiguration = {
       isAuthenticated: true,
       readOnly: false,

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -593,9 +593,9 @@ export class Hocuspocus {
       context: connection?.context || {},
       document,
       documentName: document.name,
-      requestHeaders: request?.headers,
+      requestHeaders: request?.headers ?? {},
       requestParameters: Hocuspocus.getParameters(request),
-      socketId: connection?.socketId,
+      socketId: connection?.socketId ?? '',
       update,
     }
 
@@ -611,15 +611,7 @@ export class Hocuspocus {
     }
 
     this.debounce(`onStoreDocument-${document.name}`, () => {
-      this.hooks('onStoreDocument', hookPayload)
-        .catch(error => {
-          if (error?.message) {
-            throw error
-          }
-        })
-        .then(() => {
-          this.hooks('afterStoreDocument', hookPayload)
-        })
+      this.storeDocumentHooks(document, hookPayload)
     })
   }
 

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -915,14 +915,14 @@ export class Hocuspocus {
     return this.debugger.get()?.logs
   }
 
-  getDirectConnection({ documentName, context }: { documentName: string, context?: any }): DirectConnection {
+  async getDirectConnection({ documentName, context }: { documentName: string, context?: any }): Promise<DirectConnection> {
     const connectionConfig: ConnectionConfiguration = {
       isAuthenticated: true,
       readOnly: false,
       requiresAuthentication: true,
     }
 
-    const documentPromise: Promise<Document> = this.createDocument(
+    const document: Document = await this.createDocument(
       documentName,
       {}, // direct connection has no request params
       uuid(),
@@ -930,7 +930,7 @@ export class Hocuspocus {
       context,
     )
 
-    return new DirectConnection(documentPromise, context)
+    return new DirectConnection(document, this, context)
   }
 }
 

--- a/tests/server/getConnectionsCount.ts
+++ b/tests/server/getConnectionsCount.ts
@@ -49,6 +49,23 @@ test('outputs the total connections', async t => {
   })
 })
 
+test('total connections includes direct connections', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({ name: 'hocuspocus-test' })
+
+    await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+    t.is(server.getConnectionsCount(), 1)
+
+    newHocuspocusProvider(server, {
+      onSynced() {
+        t.is(server.getConnectionsCount(), 2)
+
+        resolve('done')
+      },
+    })
+  })
+})
+
 test('adds and removes connections properly', async t => {
   const server = await newHocuspocus()
 

--- a/tests/server/getConnectionsCount.ts
+++ b/tests/server/getConnectionsCount.ts
@@ -53,7 +53,7 @@ test('total connections includes direct connections', async t => {
   await new Promise(async resolve => {
     const server = await newHocuspocus({ name: 'hocuspocus-test' })
 
-    await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+    await server.openDirectConnection('hocuspocus-test')
     t.is(server.getConnectionsCount(), 1)
 
     newHocuspocusProvider(server, {

--- a/tests/server/getDirectConnection.ts
+++ b/tests/server/getDirectConnection.ts
@@ -1,0 +1,54 @@
+import test from 'ava'
+import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
+
+test('direct connection prevents document from being removed from memory', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus()
+
+    await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+
+    const provider = newHocuspocusProvider(server, {
+      onSynced() {
+        provider.configuration.websocketProvider.destroy()
+        provider.destroy()
+
+        sleep(server.configuration.debounce + 50).then(() => {
+          t.is(server.getDocumentsCount(), 1)
+          resolve('done')
+        })
+      },
+    })
+  })
+})
+
+test('direct connection can transact', async t => {
+  const server = await newHocuspocus()
+
+  const direct = await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+
+  await direct.transact(document => {
+    document.getArray('test').insert(0, ['value'])
+  })
+
+  t.is(direct.document?.getArray('test').toJSON()[0], 'value')
+})
+
+test('direct connection cannot transact once closed', async t => {
+  const server = await newHocuspocus()
+
+  const direct = await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+  direct.disconnect()
+
+  try {
+    await direct.transact(document => {
+      document.getArray('test').insert(0, ['value'])
+    })
+    t.fail('DirectConnection should throw an error when transacting on closed connection')
+  } catch (err) {
+    if (err instanceof Error && err.message === 'direct connection closed') {
+      t.pass()
+    } else {
+      t.fail('unknown error')
+    }
+  }
+})

--- a/tests/server/onChange.ts
+++ b/tests/server/onChange.ts
@@ -123,3 +123,22 @@ test('onChange callback isn’t called for every new client', async t => {
   })
 
 })
+
+test('onChange works propery for changes from direct connections', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      name: 'hocuspocus-test',
+      async onChange(data) {
+        resolve('')
+        t.pass()
+      },
+    })
+
+    const conn = await server.openDirectConnection('hocuspocus-test')
+    t.is(server.getConnectionsCount(), 1)
+
+    conn.transact(doc => {
+      doc.getMap('t').set('g', 'b')
+    })
+  })
+})

--- a/tests/server/openDirectConnection.ts
+++ b/tests/server/openDirectConnection.ts
@@ -5,7 +5,7 @@ test('direct connection prevents document from being removed from memory', async
   await new Promise(async resolve => {
     const server = await newHocuspocus()
 
-    await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+    await server.openDirectConnection('hocuspocus-test')
 
     const provider = newHocuspocusProvider(server, {
       onSynced() {
@@ -24,7 +24,7 @@ test('direct connection prevents document from being removed from memory', async
 test('direct connection can transact', async t => {
   const server = await newHocuspocus()
 
-  const direct = await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+  const direct = await server.openDirectConnection('hocuspocus-test')
 
   await direct.transact(document => {
     document.getArray('test').insert(0, ['value'])
@@ -36,7 +36,7 @@ test('direct connection can transact', async t => {
 test('direct connection cannot transact once closed', async t => {
   const server = await newHocuspocus()
 
-  const direct = await server.getDirectConnection({ documentName: 'hocuspocus-test' })
+  const direct = await server.openDirectConnection('hocuspocus-test')
   direct.disconnect()
 
   try {


### PR DESCRIPTION
This allows server code to create an in-memory direct "connection" to a document, without a websocket.

- Introduces `openDirectConnection` function on the Hocuspocus server
- There is now a `DirectConnection` class returned by this function, and `disconnect` can be called on it
- The main method to mutate a Y.Doc is via `directConnection.transact(document => { ... })`
- Adds tests

Addresses #222 