### PR TITLE
add tests for hasUnsyncedChanges

### DIFF
--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { retryableAssertion } from 'tests/utils/retryableAssertion'
+import * as Y from 'yjs'
 import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
 
 test("initially doesn't have unsynced changes", async t => {
@@ -41,6 +42,28 @@ test('has unsynced changes when in readonly mode', async t => {
   const provider = newHocuspocusProvider(server)
 
   provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test.only('has unsynced changes when in readonly mode and initial document has changed', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+
+  const provider = newHocuspocusProvider(server, { document })
 
   await retryableAssertion(t, tt => {
     tt.is(provider.hasUnsyncedChanges, true)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -1,0 +1,86 @@
+import test from 'ava'
+import { retryableAssertion } from 'tests/utils/retryableAssertion'
+import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
+
+test("initially doesn't have unsynced changes", async t => {
+
+  const server = await newHocuspocus()
+
+  const provider = newHocuspocusProvider(server)
+
+  t.is(provider.hasUnsyncedChanges, false)
+
+})
+
+test('has unsynced changes when updating', async t => {
+
+  const server = await newHocuspocus()
+
+  const provider = newHocuspocusProvider(server)
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  // changes are synced
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, false)
+  })
+})
+
+test('has unsynced changes when in readonly mode', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const provider = newHocuspocusProvider(server)
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has unsynced changes when in readonly mode and receiving external update', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection, token }) {
+      if (token === 'readonly') {
+        connection.readOnly = true
+      }
+    },
+  })
+
+  const provider = newHocuspocusProvider(server, {
+    token: 'readonly',
+  })
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+
+  const provider2 = newHocuspocusProvider(server)
+
+  provider2.document.getMap('test2').set('foo', 'bar')
+
+  await sleep(100)
+
+  t.is(provider2.hasUnsyncedChanges, false)
+  t.is(provider.hasUnsyncedChanges, true) // TODO: this currently fails
+})

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -100,7 +100,7 @@ test('has unsynced changes when in readonly mode and initial document has change
   const provider = newHocuspocusProvider(server, { document })
 
   await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
+    tt.is(provider.hasUnsyncedChanges, true) // TODO: this also fails
   })
 
   await sleep(100)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -52,28 +52,6 @@ test('has unsynced changes when in readonly mode', async t => {
   t.is(provider.hasUnsyncedChanges, true)
 })
 
-test.only('has unsynced changes when in readonly mode and initial document has changed', async t => {
-
-  const server = await newHocuspocus({
-    async onAuthenticate({ connection }) {
-      connection.readOnly = true
-    },
-  })
-
-  const document = new Y.Doc()
-  document.getMap('test').set('foo', 'bar')
-
-  const provider = newHocuspocusProvider(server, { document })
-
-  await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
-  })
-
-  await sleep(100)
-
-  t.is(provider.hasUnsyncedChanges, true)
-})
-
 test('has unsynced changes when in readonly mode and receiving external update', async t => {
 
   const server = await newHocuspocus({
@@ -106,4 +84,26 @@ test('has unsynced changes when in readonly mode and receiving external update',
 
   t.is(provider2.hasUnsyncedChanges, false)
   t.is(provider.hasUnsyncedChanges, true) // TODO: this currently fails
+})
+
+test('has unsynced changes when in readonly mode and initial document has changed', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+
+  const provider = newHocuspocusProvider(server, { document })
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
 })


### PR DESCRIPTION
This PR adds unit tests for `hasUnsyncedChanges`.


It also surfaces an issue where the current implementation of `hasUnsyncedChanges` is broken:

The final test fails, because the implementation of `unsyncedChanges` depends on an update being "bounced back" after applied from the server to the client (source: https://github.com/YousefED/hocuspocus/blob/711f5de609a6de628700fc1ff85bfae795e24984/packages/provider/src/MessageReceiver.ts#L90). When receiving a `messageYjsUpdate`, it assumes this is the update the client sent to the server. However, the test demonstrates that the client could also be in read-only mode, and that the update can come from another client instead

