### PR TITLE
don't close when auth fails

### DIFF
--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -273,19 +273,7 @@ export class ClientConnection {
           category: message.category,
         })
 
-        // Ensure that the permission denied message is sent before the
-        // connection is closed
-        this.websocket.send(message.toUint8Array(), () => {
-          if (Object.keys(this.documentConnections).length === 0) {
-            try {
-              this.websocket.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
-            } catch (closeError) {
-              // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
-              console.error(closeError)
-              this.websocket.close(Forbidden.code, Forbidden.reason)
-            }
-          }
-        })
+        this.websocket.send(message.toUint8Array())
       }
 
       // Catch errors due to failed decoding of data

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -231,9 +231,12 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
 
     newHocuspocusProvider(server, {
       token: 'super-secret-token',
-      onClose() {
+      onAuthenticationFailed() {
         t.pass()
         resolve('done')
+      },
+      onClose() {
+        t.fail()
       },
     })
   })


### PR DESCRIPTION
This fixes and tests https://github.com/ueberdosis/hocuspocus/issues/579

There was a test for this already in place, but the issue only occured when first connecting with an invalid token, and then connecting with a valid token. In that case the connection wouldn't be established.

To resolve this, I decided to remove the closing behavior all together. For this, the other test ("stops when the onAuthenticate hook throws an Error") has also been updated