### PR TITLE
Refactor/reduce nesting and fix hookPayload per document

### DIFF
--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -80,6 +80,7 @@ export class ClientConnection {
         requiresAuthentication: boolean,
         timeout: number,
     },
+    private readonly defaultContext: any = {},
   ) {
     // Make sure to close an idle connection after a while.
     this.closeIdleConnectionTimeout = setTimeout(() => {
@@ -322,7 +323,9 @@ export class ClientConnection {
           requestHeaders: this.request.headers,
           requestParameters: getParameters(this.request),
           socketId: this.socketId,
-          context: {},
+          context: {
+            ...this.defaultContext,
+          },
         }
 
         this.hookPayloads[documentName] = hookPayload

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -28,9 +28,26 @@ import { getParameters } from './util/getParameters.js'
  * - use event handlers instead of calling hooks directly, hooks should probably be called from Hocuspocus.ts
  */
 export class ClientConnection {
+  // this map indicates whether a `Connection` instance has already taken over for incoming message for the key (i.e. documentName)
+  private readonly documentConnections: Record<string, boolean> = {}
+
+  // While the connection will be establishing messages will
+  // be queued and handled later.
+  private readonly incomingMessageQueue: Record<string, Uint8Array[]> = {}
+
+  // While the connection is establishing, kee
+  private readonly documentConnectionsEstablished = new Set<string>()
+
+  // hooks payload by Document
+  // private readonly hookPayloads: Record<string, boolean> = {}
+
+  private hookPayload: any
+
   private readonly callbacks = {
     onClose: [(document: Document, payload: onDisconnectPayload) => {}],
   }
+
+  private readonly closeIdleConnectionTimeout: NodeJS.Timeout
 
   /**
     * The `handleConnection` method receives incoming WebSocket connections,
@@ -43,7 +60,7 @@ export class ClientConnection {
     * load the Document then.
     */
   constructor(
-    incoming: WebSocket,
+    private readonly websocket: WebSocket,
     request: IncomingMessage,
     context: any = null,
     private readonly documentProvider: {
@@ -58,8 +75,8 @@ export class ClientConnection {
     },
   ) {
     // Make sure to close an idle connection after a while.
-    const closeIdleConnection = setTimeout(() => {
-      incoming.close(Unauthorized.code, Unauthorized.reason)
+    this.closeIdleConnectionTimeout = setTimeout(() => {
+      websocket.close(Unauthorized.code, Unauthorized.reason)
     }, opts.timeout)
 
     // Every new connection gets a unique identifier.
@@ -76,197 +93,17 @@ export class ClientConnection {
     // The `onConnect` and `onAuthenticate` hooks need some context
     // to decide who’s connecting, so let’s put it together:
     // TODO, keeping one instance of hookPayload causes issues like https://github.com/ueberdosis/hocuspocus/pull/613
-    const hookPayload = {
+    this.hookPayload = {
       instance: documentProvider as Hocuspocus, // TODO, this will be removed when we use events instead of hooks for this class
       request,
       requestHeaders: request.headers,
       requestParameters: getParameters(request),
       socketId,
       connection,
+      context: null,
     }
 
-    // this map indicates whether a `Connection` instance has already taken over for incoming message for the key (i.e. documentName)
-    const documentConnections: Record<string, boolean> = {}
-
-    // While the connection will be establishing messages will
-    // be queued and handled later.
-    const incomingMessageQueue: Record<string, Uint8Array[]> = {}
-
-    // While the connection is establishing
-    const connectionEstablishing: Record<string, boolean> = {}
-
-    // Once all hooks are run, we’ll fully establish the connection:
-    const setUpNewConnection = async (documentName: string) => {
-      // Not an idle connection anymore, no need to close it then.
-      clearTimeout(closeIdleConnection)
-
-      // If no hook interrupts, create a document and connection
-      const document = await documentProvider.createDocument(documentName, request, socketId, connection, context)
-      const instance = this.createConnection(incoming, request, document, socketId, connection.readOnly, context)
-
-      instance.onClose((document, event) => {
-        delete documentConnections[documentName]
-        delete incomingMessageQueue[documentName]
-        delete connectionEstablishing[documentName]
-
-        if (Object.keys(documentConnections).length === 0) {
-          instance.webSocket.close(event?.code, event?.reason) // TODO: Move this to Hocuspocus connection handler
-        }
-      })
-
-      documentConnections[documentName] = true
-
-      // There’s no need to queue messages anymore.
-      // Let’s work through queued messages.
-      incomingMessageQueue[documentName].forEach(input => {
-        incoming.emit('message', input)
-      })
-
-      this.hooks('connected', {
-        ...hookPayload,
-        documentName,
-        context,
-        connectionInstance: instance,
-      })
-    }
-
-    // This listener handles authentication messages and queues everything else.
-    const handleQueueingMessage = async (data: Uint8Array) => {
-      try {
-        const tmpMsg = new SocketIncomingMessage(data)
-
-        const documentName = decoding.readVarString(tmpMsg.decoder)
-        const type = decoding.readVarUint(tmpMsg.decoder)
-
-        if (!(type === MessageType.Auth && !connectionEstablishing[documentName])) {
-          incomingMessageQueue[documentName].push(data)
-          return
-        }
-
-        // Okay, we’ve got the authentication message we’re waiting for:
-        connectionEstablishing[documentName] = true
-
-        // The 2nd integer contains the submessage type
-        // which will always be authentication when sent from client -> server
-        decoding.readVarUint(tmpMsg.decoder)
-        const token = decoding.readVarString(tmpMsg.decoder)
-
-        this.debuggerTool.log({
-          direction: 'in',
-          type,
-          category: 'Token',
-        })
-
-        try {
-          await this.hooks('onAuthenticate', {
-            token,
-            ...hookPayload,
-            documentName,
-          }, (contextAdditions: any) => {
-            // Hooks are allowed to give us even more context and we’ll merge everything together.
-            // We’ll pass the context to other hooks then.
-            context = { ...context, ...contextAdditions }
-          })
-          // All `onAuthenticate` hooks passed.
-          connection.isAuthenticated = true
-
-          // Let the client know that authentication was successful.
-          const message = new OutgoingMessage(documentName).writeAuthenticated(connection.readOnly)
-
-          this.debuggerTool.log({
-            direction: 'out',
-            type: message.type,
-            category: message.category,
-          })
-
-          incoming.send(message.toUint8Array())
-
-          // Time to actually establish the connection.
-          await setUpNewConnection(documentName)
-        } catch (err: any) {
-          const error = err || Forbidden
-          const message = new OutgoingMessage(documentName).writePermissionDenied(error.reason ?? 'permission-denied')
-
-          this.debuggerTool.log({
-            direction: 'out',
-            type: message.type,
-            category: message.category,
-          })
-
-          // Ensure that the permission denied message is sent before the
-          // connection is closed
-          incoming.send(message.toUint8Array(), () => {
-            if (Object.keys(documentConnections).length === 0) {
-              try {
-                incoming.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
-              } catch (closeError) {
-                // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
-                console.error(closeError)
-                incoming.close(Forbidden.code, Forbidden.reason)
-              }
-            }
-          })
-        }
-
-        // Catch errors due to failed decoding of data
-      } catch (error) {
-        console.error(error)
-        incoming.close(Unauthorized.code, Unauthorized.reason)
-      }
-    }
-
-    const messageHandler = async (data: Uint8Array) => {
-      try {
-        const tmpMsg = new SocketIncomingMessage(data)
-
-        const documentName = decoding.readVarString(tmpMsg.decoder)
-
-        if (documentConnections[documentName] === true) {
-          // we already have a `Connection` set up for this document
-          return
-        }
-
-        const isFirst = incomingMessageQueue[documentName] === undefined
-        if (isFirst) {
-          incomingMessageQueue[documentName] = []
-        }
-        handleQueueingMessage(data)
-
-        if (isFirst) {
-          // if this is the first message, trigger onConnect & check if we can start the connection (only if no auth is required)
-          try {
-            await this.hooks('onConnect', { ...hookPayload, documentName }, (contextAdditions: any) => {
-              // merge context from all hooks
-              context = { ...context, ...contextAdditions }
-            })
-
-            if (connection.requiresAuthentication || connectionEstablishing[documentName]) {
-              // Authentication is required, we’ll need to wait for the Authentication message.
-              return
-            }
-            connectionEstablishing[documentName] = true
-
-            await setUpNewConnection(documentName)
-          } catch (err: any) {
-            // if a hook interrupts, close the websocket connection
-            const error = err || Forbidden
-            try {
-              incoming.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
-            } catch (closeError) {
-              // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
-              console.error(closeError)
-              incoming.close(Unauthorized.code, Unauthorized.reason)
-            }
-          }
-        }
-      } catch (closeError) {
-        // catch is needed in case an invalid payload crashes the parsing of the Uint8Array
-        console.error(closeError)
-        incoming.close(Unauthorized.code, Unauthorized.reason)
-      }
-    }
-
-    incoming.on('message', messageHandler)
+    websocket.on('message', this.messageHandler)
   }
 
   /**
@@ -281,15 +118,15 @@ export class ClientConnection {
   /**
    * Create a new connection by the given request and document
    */
-  private createConnection(connection: WebSocket, request: IncomingMessage, document: Document, socketId: string, readOnly = false, context?: any): Connection {
+  private createConnection(connection: WebSocket, document: Document): Connection {
     const instance = new Connection(
       connection,
-      request,
+      this.hookPayload.request,
       document,
       this.opts.timeout,
-      socketId,
-      context,
-      readOnly,
+      this.hookPayload.socketId,
+      this.hookPayload.context,
+      this.hookPayload.connection.readOnly,
       this.debuggerTool,
     )
 
@@ -297,12 +134,12 @@ export class ClientConnection {
       const hookPayload = {
         instance: this.documentProvider as Hocuspocus, // TODO, this will be removed when we use events instead of hooks for this class
         clientsCount: document.getConnectionsCount(),
-        context,
+        context: this.hookPayload.context,
         document,
-        socketId,
+        socketId: this.hookPayload.socketId,
         documentName: document.name,
-        requestHeaders: request.headers,
-        requestParameters: getParameters(request),
+        requestHeaders: this.hookPayload.request.headers,
+        requestParameters: getParameters(this.hookPayload.request),
       }
 
       await this.hooks('onDisconnect', hookPayload)
@@ -324,13 +161,13 @@ export class ClientConnection {
       const hookPayload: beforeHandleMessagePayload = {
         instance: this.documentProvider as Hocuspocus, // TODO, this will be removed when we use events instead of hooks for this class
         clientsCount: document.getConnectionsCount(),
-        context,
+        context: this.hookPayload.context,
         document,
-        socketId,
+        socketId: this.hookPayload.socketId,
         connection,
         documentName: document.name,
-        requestHeaders: request.headers,
-        requestParameters: getParameters(request),
+        requestHeaders: this.hookPayload.request.headers,
+        requestParameters: getParameters(this.hookPayload.request),
         update,
       }
 
@@ -349,4 +186,174 @@ export class ClientConnection {
     return instance
   }
 
+  // Once all hooks are run, we’ll fully establish the connection:
+  private setUpNewConnection = async (documentName: string) => {
+    // Not an idle connection anymore, no need to close it then.
+    clearTimeout(this.closeIdleConnectionTimeout)
+
+    // If no hook interrupts, create a document and connection
+    const document = await this.documentProvider.createDocument(documentName, this.hookPayload.request, this.hookPayload.socketId, this.hookPayload.connection, this.hookPayload.context)
+    const instance = this.createConnection(this.websocket, document)
+
+    instance.onClose((document, event) => {
+      delete this.documentConnections[documentName]
+      delete this.incomingMessageQueue[documentName]
+      this.documentConnectionsEstablished.delete(documentName)
+
+      if (Object.keys(this.documentConnections).length === 0) {
+        instance.webSocket.close(event?.code, event?.reason) // TODO: Move this to Hocuspocus connection handler
+      }
+    })
+
+    this.documentConnections[documentName] = true
+
+    // There’s no need to queue messages anymore.
+    // Let’s work through queued messages.
+    this.incomingMessageQueue[documentName].forEach(input => {
+      this.websocket.emit('message', input)
+    })
+
+    this.hooks('connected', {
+      ...this.hookPayload,
+      documentName,
+      context: this.hookPayload.context,
+      connectionInstance: instance,
+    })
+  }
+
+  // This listener handles authentication messages and queues everything else.
+  private handleQueueingMessage = async (data: Uint8Array) => {
+    try {
+      const tmpMsg = new SocketIncomingMessage(data)
+
+      const documentName = decoding.readVarString(tmpMsg.decoder)
+      const type = decoding.readVarUint(tmpMsg.decoder)
+
+      if (!(type === MessageType.Auth && !this.documentConnectionsEstablished.has(documentName))) {
+        this.incomingMessageQueue[documentName].push(data)
+        return
+      }
+
+      // Okay, we’ve got the authentication message we’re waiting for:
+      this.documentConnectionsEstablished.add(documentName)
+
+      // The 2nd integer contains the submessage type
+      // which will always be authentication when sent from client -> server
+      decoding.readVarUint(tmpMsg.decoder)
+      const token = decoding.readVarString(tmpMsg.decoder)
+
+      this.debuggerTool.log({
+        direction: 'in',
+        type,
+        category: 'Token',
+      })
+
+      try {
+        await this.hooks('onAuthenticate', {
+          token,
+          ...this.hookPayload,
+          documentName,
+        }, (contextAdditions: any) => {
+          // Hooks are allowed to give us even more context and we’ll merge everything together.
+          // We’ll pass the context to other hooks then.
+          this.hookPayload.context = { ...this.hookPayload.context, ...contextAdditions }
+        })
+        // All `onAuthenticate` hooks passed.
+        this.hookPayload.connection.isAuthenticated = true
+
+        // Let the client know that authentication was successful.
+        const message = new OutgoingMessage(documentName).writeAuthenticated(this.hookPayload.connection.readOnly)
+
+        this.debuggerTool.log({
+          direction: 'out',
+          type: message.type,
+          category: message.category,
+        })
+
+        this.websocket.send(message.toUint8Array())
+
+        // Time to actually establish the connection.
+        await this.setUpNewConnection(documentName)
+      } catch (err: any) {
+        const error = err || Forbidden
+        const message = new OutgoingMessage(documentName).writePermissionDenied(error.reason ?? 'permission-denied')
+
+        this.debuggerTool.log({
+          direction: 'out',
+          type: message.type,
+          category: message.category,
+        })
+
+        // Ensure that the permission denied message is sent before the
+        // connection is closed
+        this.websocket.send(message.toUint8Array(), () => {
+          if (Object.keys(this.documentConnections).length === 0) {
+            try {
+              this.websocket.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
+            } catch (closeError) {
+              // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
+              console.error(closeError)
+              this.websocket.close(Forbidden.code, Forbidden.reason)
+            }
+          }
+        })
+      }
+
+      // Catch errors due to failed decoding of data
+    } catch (error) {
+      console.error(error)
+      this.websocket.close(Unauthorized.code, Unauthorized.reason)
+    }
+  }
+
+  private messageHandler = async (data: Uint8Array) => {
+    try {
+      const tmpMsg = new SocketIncomingMessage(data)
+
+      const documentName = decoding.readVarString(tmpMsg.decoder)
+
+      if (this.documentConnections[documentName] === true) {
+        // we already have a `Connection` set up for this document
+        return
+      }
+
+      const isFirst = this.incomingMessageQueue[documentName] === undefined
+      if (isFirst) {
+        this.incomingMessageQueue[documentName] = []
+      }
+      this.handleQueueingMessage(data)
+
+      if (isFirst) {
+        // if this is the first message, trigger onConnect & check if we can start the connection (only if no auth is required)
+        try {
+          await this.hooks('onConnect', { ...this.hookPayload, documentName }, (contextAdditions: any) => {
+            // merge context from all hooks
+            this.hookPayload.context = { ...this.hookPayload.context, ...contextAdditions }
+          })
+
+          if (this.hookPayload.connection.requiresAuthentication || this.documentConnectionsEstablished.has(documentName)) {
+            // Authentication is required, we’ll need to wait for the Authentication message.
+            return
+          }
+          this.documentConnectionsEstablished.add(documentName)
+
+          await this.setUpNewConnection(documentName)
+        } catch (err: any) {
+          // if a hook interrupts, close the websocket connection
+          const error = err || Forbidden
+          try {
+            this.websocket.close(error.code ?? Forbidden.code, error.reason ?? Forbidden.reason)
+          } catch (closeError) {
+            // catch is needed in case invalid error code is returned by hook (that would fail sending the close message)
+            console.error(closeError)
+            this.websocket.close(Unauthorized.code, Unauthorized.reason)
+          }
+        }
+      }
+    } catch (closeError) {
+      // catch is needed in case an invalid payload crashes the parsing of the Uint8Array
+      console.error(closeError)
+      this.websocket.close(Unauthorized.code, Unauthorized.reason)
+    }
+  }
 }

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -62,7 +62,6 @@ export class ClientConnection {
   constructor(
     private readonly websocket: WebSocket,
     request: IncomingMessage,
-    context: any = null,
     private readonly documentProvider: {
         createDocument: Hocuspocus['createDocument'],
     },

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -373,11 +373,11 @@ export class Hocuspocus {
    * … and if nothings fails it’ll fully establish the connection and
    * load the Document then.
    */
-  handleConnection(incoming: WebSocket, request: IncomingMessage): void {
+  handleConnection(incoming: WebSocket, request: IncomingMessage, defaultContext: any = {}): void {
     const clientConnection = new ClientConnection(incoming, request, this, this.hooks.bind(this), this.debugger, {
       requiresAuthentication: this.requiresAuthentication,
       timeout: this.configuration.timeout,
-    })
+    }, defaultContext)
     clientConnection.onClose((document: Document, hookPayload: onDisconnectPayload) => {
       // Check if there are still no connections to the document, as these hooks
       // may take some time to resolve (e.g. database queries). If a

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -21,9 +21,10 @@ import {
   HookName,
   HookPayload,
   beforeBroadcastStatelessPayload,
+  onChangePayload,
   onDisconnectPayload,
   onListenPayload,
-  onStoreDocumentPayload, onChangePayload,
+  onStoreDocumentPayload,
 } from './types.js'
 import { getParameters } from './util/getParameters'
 
@@ -372,8 +373,8 @@ export class Hocuspocus {
    * … and if nothings fails it’ll fully establish the connection and
    * load the Document then.
    */
-  handleConnection(incoming: WebSocket, request: IncomingMessage, context: any = null): void {
-    const clientConnection = new ClientConnection(incoming, request, context, this, this.hooks.bind(this), this.debugger, {
+  handleConnection(incoming: WebSocket, request: IncomingMessage): void {
+    const clientConnection = new ClientConnection(incoming, request, this, this.hooks.bind(this), this.debugger, {
       requiresAuthentication: this.requiresAuthentication,
       timeout: this.configuration.timeout,
     })

--- a/playground/backend/src/express.ts
+++ b/playground/backend/src/express.ts
@@ -1,7 +1,7 @@
+import { Logger } from '@hocuspocus/extension-logger'
+import { Server } from '@hocuspocus/server'
 import express from 'express'
 import expressWebsockets from 'express-ws'
-import { Server } from '@hocuspocus/server'
-import { Logger } from '@hocuspocus/extension-logger'
 
 const server = Server.configure({
   extensions: [
@@ -16,8 +16,7 @@ app.get('/', (request, response) => {
 })
 
 app.ws('/:documentName', (websocket, request: any) => {
-  const context = { user_id: 1234 }
-  server.handleConnection(websocket, request, context)
+  server.handleConnection(websocket, request)
 })
 
 app.listen(1234, () => console.log('Listening on http://127.0.0.1:1234…'))

--- a/playground/backend/src/express.ts
+++ b/playground/backend/src/express.ts
@@ -16,7 +16,8 @@ app.get('/', (request, response) => {
 })
 
 app.ws('/:documentName', (websocket, request: any) => {
-  server.handleConnection(websocket, request)
+  const context = { user_id: 1234 }
+  server.handleConnection(websocket, request, context)
 })
 
 app.listen(1234, () => console.log('Listening on http://127.0.0.1:1234…'))


### PR DESCRIPTION
This refactor:
- reduces the nesting in ClientConnection.ts by extracting inline functions to class members
- fixes #579 (and adds the tests from https://github.com/ueberdosis/hocuspocus/pull/613), by making hookPayload document specific