### PR TITLE
Fix/unsyncedchanges

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "eslint.format.enable": true,
+    "javascript.format.enable": false,
+    "prettier.enable": false,
+    "typescript.format.enable": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "eslint.format.enable": true,
-    "javascript.format.enable": false,
-    "prettier.enable": false,
-    "typescript.format.enable": false
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11705,9 +11705,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.73.tgz",
-      "integrity": "sha512-aJJIElCLWnHMcYZPtsM07QoSfHwpxCy4VUzBYGXFYEmh/h2QS5uZNbCCfL0CqnkOE30b7Tp9DVfjXag+3qzZjQ==",
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11716,7 +11716,7 @@
         "0serve": "bin/0serve.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -19005,10 +19005,15 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.5.29",
-      "license": "MIT",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.4.tgz",
+      "integrity": "sha512-AirXWU/Qws6gmaz4MMluFqahweQUyLzX7QbjHmhyqbokQIki2WpE3F/NkUyOdcgEmfdTJKVys+LGgph6smZFbg==",
       "dependencies": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -19408,7 +19413,7 @@
         "@hocuspocus/server": "^2.2.0"
       },
       "peerDependencies": {
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/extension-logger": {
@@ -19473,7 +19478,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.23"
+        "yjs": "^13.6.4"
       }
     },
     "packages/extension-redis/node_modules/uuid": {
@@ -19515,7 +19520,7 @@
         "axios": "^1.2.2"
       },
       "peerDependencies": {
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/provider": {
@@ -19530,7 +19535,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/server": {
@@ -19552,7 +19557,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/server/node_modules/uuid": {
@@ -19595,7 +19600,7 @@
       "peerDependencies": {
         "@tiptap/pm": "^2.0.3",
         "y-prosemirror": "^1.0.15",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "playground/backend": {
@@ -19620,7 +19625,7 @@
         "jsonwebtoken": "^9.0.0",
         "koa": "^2.13.4",
         "koa-easy-ws": "^1.3.1",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.1",
@@ -19643,7 +19648,7 @@
         "vite-plugin-pages": "^0.29.0",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -19765,7 +19770,7 @@
         "redis": "^4.0.4",
         "sinon": "^12.0.1",
         "ws": "^8.5.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "@types/redis": "^4.0.11",
@@ -21253,7 +21258,7 @@
         "vue": "^3.2.47",
         "vue-router": "^4.1.6",
         "vue-tsc": "^1.6.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "dependencies": {
         "@vitejs/plugin-vue": {
@@ -21375,7 +21380,7 @@
         "koa-easy-ws": "^1.3.1",
         "nodemon": "^2.0.15",
         "ts-node": "^10.7.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "@hocuspocus/transformer": {
@@ -27756,9 +27761,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.73.tgz",
-      "integrity": "sha512-aJJIElCLWnHMcYZPtsM07QoSfHwpxCy4VUzBYGXFYEmh/h2QS5uZNbCCfL0CqnkOE30b7Tp9DVfjXag+3qzZjQ==",
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -31732,7 +31737,7 @@
         "sinon": "^12.0.1",
         "uuid": "^8.3.2",
         "ws": "^8.5.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "dependencies": {
         "node-fetch": {
@@ -32523,9 +32528,11 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.5.29",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.4.tgz",
+      "integrity": "sha512-AirXWU/Qws6gmaz4MMluFqahweQUyLzX7QbjHmhyqbokQIki2WpE3F/NkUyOdcgEmfdTJKVys+LGgph6smZFbg==",
       "requires": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
       }
     },
     "ylru": {

--- a/packages/extension-database/package.json
+++ b/packages/extension-database/package.json
@@ -30,7 +30,7 @@
     "@hocuspocus/server": "^2.2.0"
   },
   "peerDependencies": {
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extension-redis/package.json
+++ b/packages/extension-redis/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.23"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/extension-webhook/package.json
+++ b/packages/extension-webhook/package.json
@@ -36,7 +36,7 @@
     "axios": "^1.2.2"
   },
   "peerDependencies": {
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "cd788b6a315f608ef531524409abdce1e6790726"
 }

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -293,6 +293,12 @@ export class HocuspocusProvider extends EventEmitter {
     }, true)
   }
 
+  /**
+   * Indicates whether a first handshake with the server has been established
+   *
+   * Note: this does not mean all updates from the client have been persisted to the backend. For this,
+   * use `hasUnsyncedChanges`.
+   */
   get synced(): boolean {
     return this.isSynced
   }
@@ -390,7 +396,7 @@ export class HocuspocusProvider extends EventEmitter {
 
     this.emit('message', { event, message: new IncomingMessage(event.data) })
 
-    new MessageReceiver(message).apply(this)
+    new MessageReceiver(message).apply(this, true)
   }
 
   onClose(event: CloseEvent) {
@@ -462,7 +468,7 @@ export class HocuspocusProvider extends EventEmitter {
 
       new MessageReceiver(message)
         .setBroadcasted(true)
-        .apply(this)
+        .apply(this, false)
     })
   }
 

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -1,22 +1,31 @@
-import * as Y from 'yjs'
+import { awarenessStatesToArray } from '@hocuspocus/common'
 import * as bc from 'lib0/broadcastchannel'
-import { Awareness, removeAwarenessStates } from 'y-protocols/awareness'
 import * as mutex from 'lib0/mutex'
 import type { CloseEvent, Event, MessageEvent } from 'ws'
-import { awarenessStatesToArray } from '@hocuspocus/common'
+import { Awareness, removeAwarenessStates } from 'y-protocols/awareness'
+import * as Y from 'yjs'
 import EventEmitter from './EventEmitter.js'
+import {
+  CompleteHocuspocusProviderWebsocketConfiguration,
+  HocuspocusProviderWebsocket,
+} from './HocuspocusProviderWebsocket.js'
 import { IncomingMessage } from './IncomingMessage.js'
 import { MessageReceiver } from './MessageReceiver.js'
 import { MessageSender } from './MessageSender.js'
-import { SyncStepOneMessage } from './OutgoingMessages/SyncStepOneMessage.js'
-import { SyncStepTwoMessage } from './OutgoingMessages/SyncStepTwoMessage.js'
-import { QueryAwarenessMessage } from './OutgoingMessages/QueryAwarenessMessage.js'
 import { AuthenticationMessage } from './OutgoingMessages/AuthenticationMessage.js'
 import { AwarenessMessage } from './OutgoingMessages/AwarenessMessage.js'
+import { CloseMessage } from './OutgoingMessages/CloseMessage.js'
+import { QueryAwarenessMessage } from './OutgoingMessages/QueryAwarenessMessage.js'
+import { StatelessMessage } from './OutgoingMessages/StatelessMessage.js'
+import { SyncStepOneMessage } from './OutgoingMessages/SyncStepOneMessage.js'
+import { SyncStepTwoMessage } from './OutgoingMessages/SyncStepTwoMessage.js'
 import { UpdateMessage } from './OutgoingMessages/UpdateMessage.js'
 import {
   ConstructableOutgoingMessage,
+  WebSocketStatus,
   onAuthenticationFailedParameters,
+  onAwarenessChangeParameters,
+  onAwarenessUpdateParameters,
   onCloseParameters,
   onDisconnectParameters,
   onMessageParameters,
@@ -24,16 +33,7 @@ import {
   onOutgoingMessageParameters, onStatelessParameters,
   onStatusParameters,
   onSyncedParameters,
-  WebSocketStatus,
-  onAwarenessChangeParameters,
-  onAwarenessUpdateParameters,
 } from './types.js'
-import {
-  CompleteHocuspocusProviderWebsocketConfiguration,
-  HocuspocusProviderWebsocket,
-} from './HocuspocusProviderWebsocket.js'
-import { StatelessMessage } from './OutgoingMessages/StatelessMessage.js'
-import { CloseMessage } from './OutgoingMessages/CloseMessage.js'
 
 export type HocuspocusProviderConfiguration =
   Required<Pick<CompleteHocuspocusProviderConfiguration, 'name'>>
@@ -239,8 +239,16 @@ export class HocuspocusProvider extends EventEmitter {
     return this.unsyncedChanges > 0
   }
 
-  updateUnsyncedChanges(unsyncedChanges = 0) {
-    this.unsyncedChanges += unsyncedChanges
+  incrementUnsyncedChanges() {
+    this.unsyncedChanges += 1
+    this.emit('unsyncedChanges', this.unsyncedChanges)
+  }
+
+  decrementUnsyncedChanges() {
+    this.unsyncedChanges -= 1
+    if (this.unsyncedChanges === 0) {
+      this.synced = true
+    }
     this.emit('unsyncedChanges', this.unsyncedChanges)
   }
 
@@ -271,7 +279,7 @@ export class HocuspocusProvider extends EventEmitter {
       return
     }
 
-    this.updateUnsyncedChanges(1)
+    this.incrementUnsyncedChanges()
     this.send(UpdateMessage, { update, documentName: this.configuration.name }, true)
   }
 
@@ -292,10 +300,6 @@ export class HocuspocusProvider extends EventEmitter {
   set synced(state) {
     if (this.isSynced === state) {
       return
-    }
-
-    if (state && this.unsyncedChanges > 0) {
-      this.updateUnsyncedChanges(-1 * this.unsyncedChanges)
     }
 
     this.isSynced = state
@@ -346,6 +350,7 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   startSync() {
+    this.incrementUnsyncedChanges()
     this.send(SyncStepOneMessage, { document: this.document, documentName: this.configuration.name })
 
     if (this.awareness.getLocalState() !== null) {
@@ -358,7 +363,9 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   send(message: ConstructableOutgoingMessage, args: any, broadcast = false) {
-    if (!this.isConnected) return
+    if (!this.isConnected) {
+      return
+    }
 
     if (broadcast) {
       this.mux(() => { this.broadcast(message, args) })
@@ -455,7 +462,7 @@ export class HocuspocusProvider extends EventEmitter {
 
       new MessageReceiver(message)
         .setBroadcasted(true)
-        .apply(this, false)
+        .apply(this)
     })
   }
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -1,15 +1,15 @@
+import { Encoder } from 'lib0/encoding'
+import type { CloseEvent, Event, MessageEvent } from 'ws'
 import { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
-import { Encoder } from 'lib0/encoding'
-import type { Event, CloseEvent, MessageEvent } from 'ws'
+import { IncomingMessage } from './IncomingMessage.js'
+import { OutgoingMessage } from './OutgoingMessage.js'
 import { AuthenticationMessage } from './OutgoingMessages/AuthenticationMessage.js'
 import { AwarenessMessage } from './OutgoingMessages/AwarenessMessage.js'
 import { QueryAwarenessMessage } from './OutgoingMessages/QueryAwarenessMessage.js'
 import { SyncStepOneMessage } from './OutgoingMessages/SyncStepOneMessage.js'
 import { SyncStepTwoMessage } from './OutgoingMessages/SyncStepTwoMessage.js'
 import { UpdateMessage } from './OutgoingMessages/UpdateMessage.js'
-import { IncomingMessage } from './IncomingMessage.js'
-import { OutgoingMessage } from './OutgoingMessage.js'
 
 export enum MessageType {
   Sync = 0,
@@ -18,6 +18,7 @@ export enum MessageType {
   QueryAwareness = 3,
   Stateless = 5,
   CLOSE = 7,
+  SyncStatus = 8,
 }
 
 export enum WebSocketStatus {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -182,8 +182,6 @@ export class MessageReceiver {
         readSyncStep2(message.decoder, document, connection)
 
         if (connection) {
-          // TODO: how should this work if connection is not set? should we use reply?
-          // reply is used by redis, but I'm unsure how that code path works
           connection.send(new OutgoingMessage(document.name)
             .writeSyncStatus(true).toUint8Array())
         }
@@ -203,8 +201,6 @@ export class MessageReceiver {
 
         readUpdate(message.decoder, document, connection)
         if (connection) {
-          // TODO: how should this work if connection is not set? should we use reply?
-          // reply is used by redis, but I'm unsure how that code path works
           connection.send(new OutgoingMessage(document.name)
             .writeSyncStatus(true).toUint8Array())
         }

--- a/packages/server/src/OutgoingMessage.ts
+++ b/packages/server/src/OutgoingMessage.ts
@@ -6,12 +6,12 @@ import {
   writeVarUint,
   writeVarUint8Array,
 } from 'lib0/encoding'
-import { writeSyncStep1, writeUpdate } from 'y-protocols/sync'
 import { Awareness, encodeAwarenessUpdate } from 'y-protocols/awareness'
+import { writeSyncStep1, writeUpdate } from 'y-protocols/sync'
 
 import { writeAuthenticated, writePermissionDenied } from '@hocuspocus/common'
-import { MessageType } from './types.js'
 import Document from './Document.js'
+import { MessageType } from './types.js'
 
 export class OutgoingMessage {
 
@@ -117,6 +117,16 @@ export class OutgoingMessage {
 
     writeVarUint(this.encoder, MessageType.BroadcastStateless)
     writeVarString(this.encoder, payload)
+
+    return this
+  }
+
+  // TODO: should this be write* or create* as method name?
+  writeSyncStatus(updateSaved: boolean): OutgoingMessage {
+    this.category = 'SyncStatus'
+
+    writeVarUint(this.encoder, MessageType.SyncStatus)
+    writeVarUint(this.encoder, updateSaved ? 1 : 0)
 
     return this
   }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,9 +3,9 @@ import {
 } from 'http'
 import { URLSearchParams } from 'url'
 import { Awareness } from 'y-protocols/awareness'
+import Connection from './Connection.js'
 import Document from './Document.js'
 import { Hocuspocus } from './Hocuspocus.js'
-import Connection from './Connection.js'
 
 export enum MessageType {
   Unknown = -1,
@@ -16,8 +16,8 @@ export enum MessageType {
   SyncReply = 4, // same as Sync, but won't trigger another 'SyncStep1'
   Stateless = 5,
   BroadcastStateless = 6,
-
   CLOSE = 7,
+  SyncStatus = 8, // TODO: should this be 8?
 }
 
 export interface AwarenessUpdate {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -17,7 +17,7 @@ export enum MessageType {
   Stateless = 5,
   BroadcastStateless = 6,
   CLOSE = 7,
-  SyncStatus = 8, // TODO: should this be 8?
+  SyncStatus = 8,
 }
 
 export interface AwarenessUpdate {

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@tiptap/pm": "^2.0.3",
     "y-prosemirror": "^1.0.15",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@tiptap/pm": "^2.0.3"

--- a/playground/backend/package.json
+++ b/playground/backend/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^9.0.0",
     "koa": "^2.13.4",
     "koa-easy-ws": "^1.3.1",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.1",

--- a/playground/frontend/package.json
+++ b/playground/frontend/package.json
@@ -19,7 +19,7 @@
     "vite-plugin-pages": "^0.29.0",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "typescript": "^5.0.4",

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "redis": "^4.0.4",
     "sinon": "^12.0.1",
     "ws": "^8.5.0",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@types/redis": "^4.0.11",

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -4,26 +4,23 @@ import * as Y from 'yjs'
 import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
 
 test("initially doesn't have unsynced changes", async t => {
-
   const server = await newHocuspocus()
 
   const provider = newHocuspocusProvider(server)
 
   t.is(provider.hasUnsyncedChanges, false)
-
+  t.is(provider.synced, false)
 })
 
 test('has unsynced changes when updating', async t => {
-
   const server = await newHocuspocus()
 
-  const provider = newHocuspocusProvider(server)
+  const provider = newHocuspocusProvider(server, {
+    awareness: undefined,
+  })
 
   provider.document.getMap('test').set('foo', 'bar')
-
-  await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
-  })
+  t.is(provider.hasUnsyncedChanges, true)
 
   // changes are synced
   await retryableAssertion(t, tt => {
@@ -32,14 +29,13 @@ test('has unsynced changes when updating', async t => {
 })
 
 test('has unsynced changes when in readonly mode', async t => {
-
   const server = await newHocuspocus({
     async onAuthenticate({ connection }) {
       connection.readOnly = true
     },
   })
 
-  const provider = newHocuspocusProvider(server)
+  const provider = newHocuspocusProvider(server, { token: 'readonly' })
 
   provider.document.getMap('test').set('foo', 'bar')
 
@@ -49,11 +45,38 @@ test('has unsynced changes when in readonly mode', async t => {
 
   await sleep(100)
 
+  // confirm that the changes are not synced later either
   t.is(provider.hasUnsyncedChanges, true)
 })
 
-test('has unsynced changes when in readonly mode and receiving external update', async t => {
+test('has no unsynced changes when in readonly mode and no changes', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
 
+  const provider = newHocuspocusProvider(server, { token: 'readonly' })
+
+  // first, unsyncedChanges is briefly set to true when we're waiting for the ack of the initial sync
+  await new Promise((resolve, reject) => {
+    provider.on('unsyncedChanges', () => {
+      provider.off('unsyncedChanges')
+      if (provider.hasUnsyncedChanges) {
+        resolve('done')
+      } else {
+        reject()
+      }
+    })
+  })
+
+  // then, it should be set to false when the sync message is confirmed
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, false)
+  })
+})
+
+test('has unsynced changes when in readonly mode and receiving external update', async t => {
   const server = await newHocuspocus({
     async onAuthenticate({ connection, token }) {
       if (token === 'readonly') {
@@ -68,26 +91,28 @@ test('has unsynced changes when in readonly mode and receiving external update',
 
   provider.document.getMap('test').set('foo', 'bar')
 
-  await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
-  })
+  t.is(provider.hasUnsyncedChanges, true)
 
   await sleep(100)
 
   t.is(provider.hasUnsyncedChanges, true)
 
-  const provider2 = newHocuspocusProvider(server)
+  const provider2 = newHocuspocusProvider(server, {
+    token: 'full-access',
+  })
 
   provider2.document.getMap('test2').set('foo', 'bar')
 
-  await sleep(100)
+  t.is(provider2.hasUnsyncedChanges, true)
 
-  t.is(provider2.hasUnsyncedChanges, false)
-  t.is(provider.hasUnsyncedChanges, true) // TODO: this currently fails
+  await retryableAssertion(t, tt => {
+    tt.is(provider2.hasUnsyncedChanges, false)
+  })
+
+  t.is(provider.hasUnsyncedChanges, true)
 })
 
 test('has unsynced changes when in readonly mode and initial document has changed', async t => {
-
   const server = await newHocuspocus({
     async onAuthenticate({ connection }) {
       connection.readOnly = true
@@ -97,7 +122,7 @@ test('has unsynced changes when in readonly mode and initial document has change
   const document = new Y.Doc()
   document.getMap('test').set('foo', 'bar')
 
-  const provider = newHocuspocusProvider(server, { document })
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
 
   await retryableAssertion(t, tt => {
     tt.is(provider.hasUnsyncedChanges, true) // TODO: this also fails
@@ -106,4 +131,20 @@ test('has unsynced changes when in readonly mode and initial document has change
   await sleep(100)
 
   t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has no unsynced changes when in readonly mode and initial document has not changed', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, false)
 })

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -125,7 +125,34 @@ test('has unsynced changes when in readonly mode and initial document has change
   const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
 
   await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true) // TODO: this also fails
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test.only('has unsynced changes when in readonly mode and initial document has changed (deletion)', async t => {
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+  const initialState = Y.encodeStateAsUpdate(document)
+
+  const server = await newHocuspocus({
+    async onLoadDocument() {
+      return initialState
+    },
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  document.getMap('test').delete('foo')
+
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
   })
 
   await sleep(100)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { retryableAssertion } from 'tests/utils/retryableAssertion'
+import * as Y from 'yjs'
 import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
 
 test("initially doesn't have unsynced changes", async t => {
@@ -41,6 +42,28 @@ test('has unsynced changes when in readonly mode', async t => {
   const provider = newHocuspocusProvider(server)
 
   provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test.only('has unsynced changes when in readonly mode and initial document has changed', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+
+  const provider = newHocuspocusProvider(server, { document })
 
   await retryableAssertion(t, tt => {
     tt.is(provider.hasUnsyncedChanges, true)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -1,0 +1,86 @@
+import test from 'ava'
+import { retryableAssertion } from 'tests/utils/retryableAssertion'
+import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
+
+test("initially doesn't have unsynced changes", async t => {
+
+  const server = await newHocuspocus()
+
+  const provider = newHocuspocusProvider(server)
+
+  t.is(provider.hasUnsyncedChanges, false)
+
+})
+
+test('has unsynced changes when updating', async t => {
+
+  const server = await newHocuspocus()
+
+  const provider = newHocuspocusProvider(server)
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  // changes are synced
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, false)
+  })
+})
+
+test('has unsynced changes when in readonly mode', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const provider = newHocuspocusProvider(server)
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has unsynced changes when in readonly mode and receiving external update', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection, token }) {
+      if (token === 'readonly') {
+        connection.readOnly = true
+      }
+    },
+  })
+
+  const provider = newHocuspocusProvider(server, {
+    token: 'readonly',
+  })
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+
+  const provider2 = newHocuspocusProvider(server)
+
+  provider2.document.getMap('test2').set('foo', 'bar')
+
+  await sleep(100)
+
+  t.is(provider2.hasUnsyncedChanges, false)
+  t.is(provider.hasUnsyncedChanges, true) // TODO: this currently fails
+})

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -100,7 +100,7 @@ test('has unsynced changes when in readonly mode and initial document has change
   const provider = newHocuspocusProvider(server, { document })
 
   await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
+    tt.is(provider.hasUnsyncedChanges, true) // TODO: this also fails
   })
 
   await sleep(100)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -133,7 +133,7 @@ test('has unsynced changes when in readonly mode and initial document has change
   t.is(provider.hasUnsyncedChanges, true)
 })
 
-test.only('has unsynced changes when in readonly mode and initial document has changed (deletion)', async t => {
+test('has unsynced changes when in readonly mode and initial document has changed (deletion)', async t => {
   const document = new Y.Doc()
   document.getMap('test').set('foo', 'bar')
   const initialState = Y.encodeStateAsUpdate(document)

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -4,12 +4,22 @@ import * as Y from 'yjs'
 import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
 
 test("initially doesn't have unsynced changes", async t => {
-  const server = await newHocuspocus()
+  return new Promise(async resolve => {
 
-  const provider = newHocuspocusProvider(server)
+    const server = await newHocuspocus()
 
-  t.is(provider.hasUnsyncedChanges, false)
-  t.is(provider.synced, false)
+    const provider = newHocuspocusProvider(server)
+
+    t.is(provider.hasUnsyncedChanges, false)
+    t.is(provider.synced, false)
+
+    setTimeout(() => {
+      t.is(provider.hasUnsyncedChanges, false)
+      t.is(provider.synced, true)
+
+      resolve()
+    }, 100)
+  })
 })
 
 test('has unsynced changes when updating', async t => {

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -52,28 +52,6 @@ test('has unsynced changes when in readonly mode', async t => {
   t.is(provider.hasUnsyncedChanges, true)
 })
 
-test.only('has unsynced changes when in readonly mode and initial document has changed', async t => {
-
-  const server = await newHocuspocus({
-    async onAuthenticate({ connection }) {
-      connection.readOnly = true
-    },
-  })
-
-  const document = new Y.Doc()
-  document.getMap('test').set('foo', 'bar')
-
-  const provider = newHocuspocusProvider(server, { document })
-
-  await retryableAssertion(t, tt => {
-    tt.is(provider.hasUnsyncedChanges, true)
-  })
-
-  await sleep(100)
-
-  t.is(provider.hasUnsyncedChanges, true)
-})
-
 test('has unsynced changes when in readonly mode and receiving external update', async t => {
 
   const server = await newHocuspocus({
@@ -106,4 +84,26 @@ test('has unsynced changes when in readonly mode and receiving external update',
 
   t.is(provider2.hasUnsyncedChanges, false)
   t.is(provider.hasUnsyncedChanges, true) // TODO: this currently fails
+})
+
+test('has unsynced changes when in readonly mode and initial document has changed', async t => {
+
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+
+  const provider = newHocuspocusProvider(server, { document })
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
 })

--- a/tests/provider/onAwarenessChange.ts
+++ b/tests/provider/onAwarenessChange.ts
@@ -94,6 +94,16 @@ test('gets the current awareness states from the server', async t => {
             direction: 'out',
             type: 'Awareness',
           },
+          {
+            category: 'Update',
+            direction: 'in',
+            type: 'Awareness',
+          },
+          {
+            category: 'SyncStep2',
+            direction: 'in',
+            type: 'Sync',
+          },
         ])
 
         resolve('done')

--- a/tests/provider/onAwarenessChange.ts
+++ b/tests/provider/onAwarenessChange.ts
@@ -68,45 +68,48 @@ test('gets the current awareness states from the server', async t => {
 
     const provider = newHocuspocusProvider(server, {
       onSynced() {
-        t.deepEqual(server.getMessageLogs(), [
-          {
-            category: 'SyncStep1',
-            direction: 'in',
-            type: 'Sync',
-          },
-          {
-            category: 'SyncStep2',
-            direction: 'out',
-            type: 'Sync',
-          },
-          {
-            category: 'SyncStep1',
-            direction: 'out',
-            type: 'Sync',
-          },
-          {
-            category: 'Update',
-            direction: 'in',
-            type: 'Awareness',
-          },
-          {
-            category: 'Update',
-            direction: 'out',
-            type: 'Awareness',
-          },
-          {
-            category: 'Update',
-            direction: 'in',
-            type: 'Awareness',
-          },
-          {
-            category: 'SyncStep2',
-            direction: 'in',
-            type: 'Sync',
-          },
-        ])
+        setTimeout(() => {
 
-        resolve('done')
+          t.deepEqual(server.getMessageLogs(), [
+            {
+              category: 'SyncStep1',
+              direction: 'in',
+              type: 'Sync',
+            },
+            {
+              category: 'SyncStep2',
+              direction: 'out',
+              type: 'Sync',
+            },
+            {
+              category: 'SyncStep1',
+              direction: 'out',
+              type: 'Sync',
+            },
+            {
+              category: 'Update',
+              direction: 'in',
+              type: 'Awareness',
+            },
+            {
+              category: 'Update',
+              direction: 'out',
+              type: 'Awareness',
+            },
+            {
+              category: 'Update',
+              direction: 'in',
+              type: 'Awareness',
+            },
+            {
+              category: 'SyncStep2',
+              direction: 'in',
+              type: 'Sync',
+            },
+          ])
+
+          resolve('done')
+        }, 100)
       },
     })
 

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -241,7 +241,7 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
 
 test('if a new connection connects while the previous connection still fetches the document, it will just work properly', async t => {
   let callsToOnLoadDocument = 0
-  const resolvesNeeded = 7
+  const resolvesNeeded = 11
 
   await new Promise(async resolve => {
 
@@ -289,6 +289,10 @@ test('if a new connection connects while the previous connection still fetches t
         const value = provider.document.getArray('foo').get(0)
 
         if (provider1MessagesReceived === 1) {
+          // do nothing, this is just the ACK for the sync
+        } else if (provider1MessagesReceived === 2) {
+          // do nothing, this is just the ACK for the received update (set "bar-updatedAfterProvider1Synced")
+        } else if (provider1MessagesReceived === 3) {
           t.is(value, 'bar-updatedAfterProvider1Synced')
         } else {
           t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
@@ -318,8 +322,12 @@ test('if a new connection connects while the previous connection still fetches t
           const value = provider.document.getArray('foo').get(0)
 
           if (provider2MessagesReceived === 1) {
+            // do nothing, this is just the ACK for the sync
             t.is(value, undefined)
           } else if (provider2MessagesReceived === 2) {
+            // initial state is now synced
+            t.is(value, undefined)
+          } else if (provider2MessagesReceived === 3) {
             t.is(value, 'bar-updatedAfterProvider1Synced')
             setTimeout(() => {
               provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])


### PR DESCRIPTION
This PR introduces a SyncStatus message that acknowledges Initial Syncs and Updates sent to HocusPocus. This fixes some bugs in `unsyncedChanges` (see #614). This PR makes it possible for clients to know whether all their changes have been accepted by the server or not.

- fixed a bug where messages were silently discarded in HocuspocusProviderWebsocket (by implementing a queue)
- Had to upgrade yjs to get `snapshotContainsUpdate`
- 3 outstanding questions ("TODO")
- 2 tests still fail - I'm not sure how to fix these
- based off https://github.com/ueberdosis/hocuspocus/pull/631, best to merge that first
- closes https://github.com/ueberdosis/hocuspocus/pull/614