### PR TITLE
fixes: HocuspocusProviderWebsocket checkConnection ineffective

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -1,6 +1,5 @@
 import * as Y from 'yjs'
 import * as bc from 'lib0/broadcastchannel'
-import * as time from 'lib0/time'
 import { Awareness, removeAwarenessStates } from 'y-protocols/awareness'
 import * as mutex from 'lib0/mutex'
 import type { CloseEvent, Event, MessageEvent } from 'ws'
@@ -369,8 +368,6 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   onMessage(event: MessageEvent) {
-    this.configuration.websocketProvider.lastMessageReceived = time.getUnixTime()
-
     const message = new IncomingMessage(event.data)
 
     const documentName = message.readVarString()

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -1,5 +1,6 @@
 import * as Y from 'yjs'
 import * as bc from 'lib0/broadcastchannel'
+import * as time from 'lib0/time'
 import { Awareness, removeAwarenessStates } from 'y-protocols/awareness'
 import * as mutex from 'lib0/mutex'
 import type { CloseEvent, Event, MessageEvent } from 'ws'
@@ -368,6 +369,8 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   onMessage(event: MessageEvent) {
+    this.configuration.websocketProvider.lastMessageReceived = time.getUnixTime()
+
     const message = new IncomingMessage(event.data)
 
     const documentName = message.readVarString()

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -313,6 +313,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
   onMessage(event: MessageEvent) {
     this.resolveConnectionAttempt()
+
+    this.lastMessageReceived = time.getUnixTime()
   }
 
   resolveConnectionAttempt() {


### PR DESCRIPTION
In the v1.1.3, `onMessage` will update `lastMessageReceived` as follow
```
onMessage(event: MessageEvent) {
    this.resolveConnectionAttempt()

    this.lastMessageReceived = time.getUnixTime()

    const message = new IncomingMessage(event.data)

    this.emit('message', { event, message })

    new MessageReceiver(message).apply(this)
  }
```
In the  v2.2.0, onMessage not update lastMessageReceived.

```
//HocuspocusProviderWebsocket.ts
onMessage(event: MessageEvent) {
    this.resolveConnectionAttempt()
}
```

```
//HocuspocusProvider.ts
onMessage(event: MessageEvent) {
    const message = new IncomingMessage(event.data)

    const documentName = message.readVarString()

    if (documentName !== this.configuration.name) {
      return // message is meant for another provider
    }

    message.writeVarString(documentName)

    this.emit('message', { event, message: new IncomingMessage(event.data) })

    new MessageReceiver(message).apply(this)
}
```
If the client switch its network from WIFI to LTE  or vice versa,

`checkConnection` can not able to  call  `webSocket?.close()` because of `lastMessageReceived = 0` in HocuspocusProviderWebsocket constructor.

```
checkConnection() {
    // Don’t check the connection when it’s not even established
    if (this.status !== WebSocketStatus.Connected) {
      return
    }

    // Don’t close then connection while waiting for the first message
    if (!this.lastMessageReceived) {
      return
    }

    // Don’t close the connection when a message was received recently
    if (this.configuration.messageReconnectTimeout >= time.getUnixTime() - this.lastMessageReceived) {
      return
    }

    // No message received in a long time, not even your own
    // Awareness updates, which are updated every 15 seconds.
    this.webSocket?.close()
  }
```

this case can be reproduce  in iOS safari or iOS webview(iPhone 15E148 605.1, webkit version:605.1.15), but not easy to find in windows(chrome)、android（chrome/webview)

