### PR TITLE
Add CloseEvents.IdleTimeout

### DIFF
--- a/packages/common/src/CloseEvents.ts
+++ b/packages/common/src/CloseEvents.ts
@@ -47,3 +47,12 @@ export const ConnectionTimeout: CloseEvent = {
   code: 4408,
   reason: 'Connection Timeout',
 }
+
+/**
+ * The server timed out after the client became idle.
+ * See closeIdleConnectionTimeout
+ */
+export const IdleTimeout: CloseEvent = {
+  code: 4409,
+  reason: 'Idle Timeout',
+}

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -4,7 +4,7 @@ import * as url from 'lib0/url'
 import type { MessageEvent } from 'ws'
 import { retry } from '@lifeomic/attempt'
 import {
-  Forbidden, MessageTooBig, Unauthorized, WsReadyStates,
+  Forbidden, IdleTimeout, MessageTooBig, Unauthorized, WsReadyStates,
 } from '@hocuspocus/common'
 import { Event } from 'ws'
 import EventEmitter from './EventEmitter.js'
@@ -416,6 +416,16 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
         console.warn('[HocuspocusProvider] An authentication token is required, but you didn’t send one. Try adding a `token` to your HocuspocusProvider configuration. Won’t try again.')
       } else {
         console.warn(`[HocuspocusProvider] Connection closed with status Unauthorized: ${event.reason}`)
+      }
+
+      this.shouldConnect = false
+    }
+
+    if (event.code === IdleTimeout.code) {
+      if (event.reason === IdleTimeout.reason) {
+        console.info('[HocuspocusProvider] Connection timed out due to inactivity.')
+      } else {
+        console.info(`[HocuspocusProvider] Connection closed with status IdleTimeout: ${event.reason}`)
       }
 
       this.shouldConnect = false

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -1,6 +1,6 @@
 import { IncomingHttpHeaders, IncomingMessage } from 'http'
 import {
-  Forbidden, Unauthorized, WsReadyStates,
+  Forbidden, IdleTimeout, Unauthorized, WsReadyStates,
 } from '@hocuspocus/common'
 import * as decoding from 'lib0/decoding'
 import { v4 as uuid } from 'uuid'
@@ -84,7 +84,7 @@ export class ClientConnection {
   ) {
     // Make sure to close an idle connection after a while.
     this.closeIdleConnectionTimeout = setTimeout(() => {
-      websocket.close(Unauthorized.code, Unauthorized.reason)
+      websocket.close(IdleTimeout.code, IdleTimeout.reason)
     }, opts.timeout)
 
     websocket.on('message', this.messageHandler)


### PR DESCRIPTION
When the connection becomes idle, it is currently closed with an `Unauthorized` close event. However, this isn't a good fit for an idle timeout. The browser gives an inaccurate warning: `An authentication token is required, but you didn’t send one. Try adding a `token` to your HocuspocusProvider configuration. Won’t try again.`

I added an `IdleTimeout` close event that better matches the reason.