### PR TITLE
Fix import paths (for `node16`) resolution

### DIFF
--- a/packages/server/src/DirectConnection.ts
+++ b/packages/server/src/DirectConnection.ts
@@ -1,7 +1,7 @@
 import { URLSearchParams } from 'url'
 import Document from './Document.js'
 import type { Hocuspocus } from './Hocuspocus.js'
-import type { DirectConnection as DirectConnectionInterface } from './types'
+import type { DirectConnection as DirectConnectionInterface } from './types.js'
 
 export class DirectConnection implements DirectConnectionInterface {
   document: Document | null = null

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -26,7 +26,7 @@ import {
   onListenPayload,
   onStoreDocumentPayload,
 } from './types.js'
-import { getParameters } from './util/getParameters'
+import { getParameters } from './util/getParameters.js'
 
 export const defaultConfiguration = {
   name: null,


### PR DESCRIPTION
Two imports in `@hocuspocus/server` were missing their file extensions so that the package could not be used with a `node16` package resolution strategy. See #608.