### PR TITLE
Optimize typescript typings of the TiptapCollabProvider

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -9,13 +9,13 @@ export type TiptapCollabProviderConfiguration =
   Required<Pick<HocuspocusProviderConfiguration, 'name'>> &
   Partial<HocuspocusProviderConfiguration> &
   (Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'websocketProvider'>> |
-  AdditionalTiptapCollabProviderConfiguration)
+  Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'appId'>>)
 
 export interface AdditionalTiptapCollabProviderConfiguration {
   /**
    * A Hocuspocus Cloud App ID, get one here: https://collab.tiptap.dev
    */
-  appId: string,
+  appId?: string,
 
   websocketProvider?: TiptapCollabProviderWebsocket
 }
@@ -23,7 +23,7 @@ export interface AdditionalTiptapCollabProviderConfiguration {
 export class TiptapCollabProvider extends HocuspocusProvider {
   constructor(configuration: TiptapCollabProviderConfiguration) {
     if (!configuration.websocketProvider) {
-      configuration.websocketProvider = new TiptapCollabProviderWebsocket({ appId: (configuration as AdditionalTiptapCollabProviderConfiguration).appId })
+      configuration.websocketProvider = new TiptapCollabProviderWebsocket({ appId: (configuration as Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'appId'>>).appId })
     }
 
     if (!configuration.token) {

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -8,7 +8,8 @@ import { TiptapCollabProviderWebsocket } from './TiptapCollabProviderWebsocket.j
 export type TiptapCollabProviderConfiguration =
   Required<Pick<HocuspocusProviderConfiguration, 'name'>> &
   Partial<HocuspocusProviderConfiguration> &
-  AdditionalTiptapCollabProviderConfiguration
+  ({ websocketProvider: TiptapCollabProviderWebsocket } |
+  AdditionalTiptapCollabProviderConfiguration)
 
 export interface AdditionalTiptapCollabProviderConfiguration {
   /**
@@ -20,7 +21,7 @@ export interface AdditionalTiptapCollabProviderConfiguration {
 export class TiptapCollabProvider extends HocuspocusProvider {
   constructor(configuration: TiptapCollabProviderConfiguration) {
     if (!configuration.websocketProvider) {
-      configuration.websocketProvider = new TiptapCollabProviderWebsocket({ appId: configuration.appId })
+      configuration.websocketProvider = new TiptapCollabProviderWebsocket({ appId: (configuration as AdditionalTiptapCollabProviderConfiguration).appId })
     }
 
     if (!configuration.token) {

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -8,7 +8,7 @@ import { TiptapCollabProviderWebsocket } from './TiptapCollabProviderWebsocket.j
 export type TiptapCollabProviderConfiguration =
   Required<Pick<HocuspocusProviderConfiguration, 'name'>> &
   Partial<HocuspocusProviderConfiguration> &
-  ({ websocketProvider: TiptapCollabProviderWebsocket } |
+  (Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'websocketProvider'>> |
   AdditionalTiptapCollabProviderConfiguration)
 
 export interface AdditionalTiptapCollabProviderConfiguration {
@@ -16,6 +16,8 @@ export interface AdditionalTiptapCollabProviderConfiguration {
    * A Hocuspocus Cloud App ID, get one here: https://collab.tiptap.dev
    */
   appId: string,
+
+  websocketProvider?: TiptapCollabProviderWebsocket
 }
 
 export class TiptapCollabProvider extends HocuspocusProvider {


### PR DESCRIPTION
we don't need the appId if a custom websocketProvider is being passed