### PR TITLE
Fix/unsyncedchanges (#635)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11705,9 +11705,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.73.tgz",
-      "integrity": "sha512-aJJIElCLWnHMcYZPtsM07QoSfHwpxCy4VUzBYGXFYEmh/h2QS5uZNbCCfL0CqnkOE30b7Tp9DVfjXag+3qzZjQ==",
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11716,7 +11716,7 @@
         "0serve": "bin/0serve.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -19005,10 +19005,15 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.5.29",
-      "license": "MIT",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.4.tgz",
+      "integrity": "sha512-AirXWU/Qws6gmaz4MMluFqahweQUyLzX7QbjHmhyqbokQIki2WpE3F/NkUyOdcgEmfdTJKVys+LGgph6smZFbg==",
       "dependencies": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -19408,7 +19413,7 @@
         "@hocuspocus/server": "^2.2.3"
       },
       "peerDependencies": {
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/extension-logger": {
@@ -19473,7 +19478,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.23"
+        "yjs": "^13.6.4"
       }
     },
     "packages/extension-redis/node_modules/uuid": {
@@ -19515,7 +19520,7 @@
         "axios": "^1.2.2"
       },
       "peerDependencies": {
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/provider": {
@@ -19530,7 +19535,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/server": {
@@ -19552,7 +19557,7 @@
       },
       "peerDependencies": {
         "y-protocols": "^1.0.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "packages/server/node_modules/uuid": {
@@ -19595,7 +19600,7 @@
       "peerDependencies": {
         "@tiptap/pm": "^2.0.3",
         "y-prosemirror": "^1.0.15",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "playground/backend": {
@@ -19620,7 +19625,7 @@
         "jsonwebtoken": "^9.0.0",
         "koa": "^2.13.4",
         "koa-easy-ws": "^1.3.1",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.1",
@@ -19643,7 +19648,7 @@
         "vite-plugin-pages": "^0.29.0",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "typescript": "^5.0.4",
@@ -19765,7 +19770,7 @@
         "redis": "^4.0.4",
         "sinon": "^12.0.1",
         "ws": "^8.5.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "devDependencies": {
         "@types/redis": "^4.0.11",
@@ -21253,7 +21258,7 @@
         "vue": "^3.2.47",
         "vue-router": "^4.1.6",
         "vue-tsc": "^1.6.5",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "dependencies": {
         "@vitejs/plugin-vue": {
@@ -21375,7 +21380,7 @@
         "koa-easy-ws": "^1.3.1",
         "nodemon": "^2.0.15",
         "ts-node": "^10.7.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       }
     },
     "@hocuspocus/transformer": {
@@ -27756,9 +27761,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.73.tgz",
-      "integrity": "sha512-aJJIElCLWnHMcYZPtsM07QoSfHwpxCy4VUzBYGXFYEmh/h2QS5uZNbCCfL0CqnkOE30b7Tp9DVfjXag+3qzZjQ==",
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -31732,7 +31737,7 @@
         "sinon": "^12.0.1",
         "uuid": "^8.3.2",
         "ws": "^8.5.0",
-        "yjs": "^13.5.29"
+        "yjs": "^13.6.4"
       },
       "dependencies": {
         "node-fetch": {
@@ -32523,9 +32528,11 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.5.29",
+      "version": "13.6.4",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.4.tgz",
+      "integrity": "sha512-AirXWU/Qws6gmaz4MMluFqahweQUyLzX7QbjHmhyqbokQIki2WpE3F/NkUyOdcgEmfdTJKVys+LGgph6smZFbg==",
       "requires": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.74"
       }
     },
     "ylru": {

--- a/packages/extension-database/package.json
+++ b/packages/extension-database/package.json
@@ -30,7 +30,7 @@
     "@hocuspocus/server": "^2.2.3"
   },
   "peerDependencies": {
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extension-redis/package.json
+++ b/packages/extension-redis/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.23"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/extension-webhook/package.json
+++ b/packages/extension-webhook/package.json
@@ -36,7 +36,7 @@
     "axios": "^1.2.2"
   },
   "peerDependencies": {
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "cd788b6a315f608ef531524409abdce1e6790726"
 }

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -1,18 +1,19 @@
-import * as time from 'lib0/time'
-import * as mutex from 'lib0/mutex'
-import * as url from 'lib0/url'
-import type { MessageEvent } from 'ws'
-import { retry } from '@lifeomic/attempt'
 import {
   Forbidden, MessageTooBig, Unauthorized, WsReadyStates,
 } from '@hocuspocus/common'
+import { retry } from '@lifeomic/attempt'
+import * as mutex from 'lib0/mutex'
+import * as time from 'lib0/time'
+import * as url from 'lib0/url'
+import type { MessageEvent } from 'ws'
 import { Event } from 'ws'
 import EventEmitter from './EventEmitter.js'
-import {
-  onCloseParameters, onDisconnectParameters, onMessageParameters, onOpenParameters, onOutgoingMessageParameters, onStatusParameters, WebSocketStatus,
-  onAwarenessChangeParameters, onAwarenessUpdateParameters,
-} from './types.js'
 import { HocuspocusProvider } from './HocuspocusProvider.js'
+import {
+  WebSocketStatus,
+  onAwarenessChangeParameters, onAwarenessUpdateParameters,
+  onCloseParameters, onDisconnectParameters, onMessageParameters, onOpenParameters, onOutgoingMessageParameters, onStatusParameters,
+} from './types.js'
 
 export type HocuspocusProviderWebsocketConfiguration =
   Required<Pick<CompleteHocuspocusProviderWebsocketConfiguration, 'url'>>
@@ -91,6 +92,8 @@ export interface CompleteHocuspocusProviderWebsocketConfiguration {
 }
 
 export class HocuspocusProviderWebsocket extends EventEmitter {
+  private messageQueue: any[] = []
+
   public configuration: CompleteHocuspocusProviderWebsocketConfiguration = {
     url: '',
     // @ts-ignore
@@ -285,6 +288,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   createWebSocketConnection() {
     return new Promise((resolve, reject) => {
       if (this.webSocket) {
+        this.messageQueue = []
         this.webSocket.close()
         this.webSocket = null
       }
@@ -326,6 +330,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
       this.status = WebSocketStatus.Connected
       this.emit('status', { status: WebSocketStatus.Connected })
       this.emit('connect')
+      this.messageQueue.forEach(message => this.send(message))
+      this.messageQueue = []
     }
   }
 
@@ -357,6 +363,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     // No message received in a long time, not even your own
     // Awareness updates, which are updated every 15 seconds.
     this.webSocket?.close()
+    this.messageQueue = []
   }
 
   registerEventListeners() {
@@ -391,6 +398,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     try {
       this.webSocket.close()
+      this.messageQueue = []
     } catch {
       //
     }
@@ -399,6 +407,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   send(message: any) {
     if (this.webSocket?.readyState === WsReadyStates.Open) {
       this.webSocket.send(message)
+    } else {
+      this.messageQueue.push(message)
     }
   }
 

--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -1,11 +1,11 @@
-import * as awarenessProtocol from 'y-protocols/awareness'
-import { readSyncMessage, messageYjsSyncStep2, messageYjsUpdate } from 'y-protocols/sync'
 import { readAuthMessage } from '@hocuspocus/common'
-import { readVarString } from 'lib0/decoding'
-import { MessageType } from './types.js'
+import { readVarInt, readVarString } from 'lib0/decoding'
+import * as awarenessProtocol from 'y-protocols/awareness'
+import { messageYjsSyncStep2, readSyncMessage } from 'y-protocols/sync'
 import { HocuspocusProvider } from './HocuspocusProvider.js'
 import { IncomingMessage } from './IncomingMessage.js'
 import { OutgoingMessage } from './OutgoingMessage.js'
+import { MessageType } from './types.js'
 
 export class MessageReceiver {
 
@@ -23,7 +23,7 @@ export class MessageReceiver {
     return this
   }
 
-  public apply(provider: HocuspocusProvider, emitSynced = true) {
+  public apply(provider: HocuspocusProvider, emitSynced: boolean) {
     const { message } = this
     const type = message.readVarUint()
 
@@ -51,9 +51,8 @@ export class MessageReceiver {
         break
 
       case MessageType.SyncStatus:
-        // nothing for now; forward-compatability
+        this.applySyncStatusMessage(provider, readVarInt(message.decoder) === 1)
         break
-
       default:
         throw new Error(`Can’t apply message of unknown type: ${type}`)
     }
@@ -89,11 +88,11 @@ export class MessageReceiver {
     if (emitSynced && syncMessageType === messageYjsSyncStep2) {
       provider.synced = true
     }
+  }
 
-    if (syncMessageType === messageYjsUpdate || syncMessageType === messageYjsSyncStep2) {
-      if (provider.unsyncedChanges > 0) {
-        provider.updateUnsyncedChanges(-1)
-      }
+  applySyncStatusMessage(provider: HocuspocusProvider, applied: boolean) {
+    if (applied) {
+      provider.decrementUnsyncedChanges()
     }
   }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "y-protocols": "^1.0.5",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "gitHead": "b3454a4ca289a84ddfb7fa5607a2d4b8d5c37e9d"
 }

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -1,3 +1,6 @@
+import * as decoding from 'lib0/decoding'
+import { readVarString } from 'lib0/decoding'
+import { applyAwarenessUpdate } from 'y-protocols/awareness'
 import {
   messageYjsSyncStep1,
   messageYjsSyncStep2,
@@ -6,14 +9,13 @@ import {
   readSyncStep2,
   readUpdate,
 } from 'y-protocols/sync'
-import { applyAwarenessUpdate } from 'y-protocols/awareness'
-import { readVarString } from 'lib0/decoding'
-import { MessageType } from './types.js'
+import * as Y from 'yjs'
 import Connection from './Connection.js'
-import { IncomingMessage } from './IncomingMessage.js'
-import { OutgoingMessage } from './OutgoingMessage.js'
 import { Debugger } from './Debugger.js'
 import Document from './Document.js'
+import { IncomingMessage } from './IncomingMessage.js'
+import { OutgoingMessage } from './OutgoingMessage.js'
+import { MessageType } from './types.js'
 
 export class MessageReceiver {
 
@@ -156,10 +158,33 @@ export class MessageReceiver {
         })
 
         if (connection?.readOnly) {
+          // We're in read-only mode, so we can't apply the update.
+          // Let's use snapshotContainsUpdate to see if the update actually contains changes.
+          // If not, we can still ack the update
+          const snapshot = Y.snapshot(document)
+          const update = decoding.readVarUint8Array(message.decoder)
+          if (Y.snapshotContainsUpdate(snapshot, update)) {
+            // no new changes in update
+            const ackMessage = new OutgoingMessage(document.name)
+              .writeSyncStatus(true)
+
+            connection.send(ackMessage.toUint8Array())
+          } else {
+            // new changes in update that we can't apply, because readOnly
+            const ackMessage = new OutgoingMessage(document.name)
+              .writeSyncStatus(false)
+
+            connection.send(ackMessage.toUint8Array())
+          }
           break
         }
 
         readSyncStep2(message.decoder, document, connection)
+
+        if (connection) {
+          connection.send(new OutgoingMessage(document.name)
+            .writeSyncStatus(true).toUint8Array())
+        }
         break
       case messageYjsUpdate:
         this.logger.log({
@@ -169,10 +194,16 @@ export class MessageReceiver {
         })
 
         if (connection?.readOnly) {
+          connection.send(new OutgoingMessage(document.name)
+            .writeSyncStatus(false).toUint8Array())
           break
         }
 
         readUpdate(message.decoder, document, connection)
+        if (connection) {
+          connection.send(new OutgoingMessage(document.name)
+            .writeSyncStatus(true).toUint8Array())
+        }
         break
       default:
         throw new Error(`Received a message with an unknown type: ${type}`)

--- a/packages/server/src/OutgoingMessage.ts
+++ b/packages/server/src/OutgoingMessage.ts
@@ -6,12 +6,12 @@ import {
   writeVarUint,
   writeVarUint8Array,
 } from 'lib0/encoding'
-import { writeSyncStep1, writeUpdate } from 'y-protocols/sync'
 import { Awareness, encodeAwarenessUpdate } from 'y-protocols/awareness'
+import { writeSyncStep1, writeUpdate } from 'y-protocols/sync'
 
 import { writeAuthenticated, writePermissionDenied } from '@hocuspocus/common'
-import { MessageType } from './types.js'
 import Document from './Document.js'
+import { MessageType } from './types.js'
 
 export class OutgoingMessage {
 
@@ -117,6 +117,16 @@ export class OutgoingMessage {
 
     writeVarUint(this.encoder, MessageType.BroadcastStateless)
     writeVarString(this.encoder, payload)
+
+    return this
+  }
+
+  // TODO: should this be write* or create* as method name?
+  writeSyncStatus(updateSaved: boolean): OutgoingMessage {
+    this.category = 'SyncStatus'
+
+    writeVarUint(this.encoder, MessageType.SyncStatus)
+    writeVarUint(this.encoder, updateSaved ? 1 : 0)
 
     return this
   }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,9 +3,9 @@ import {
 } from 'http'
 import { URLSearchParams } from 'url'
 import { Awareness } from 'y-protocols/awareness'
+import Connection from './Connection.js'
 import Document from './Document.js'
 import { Hocuspocus } from './Hocuspocus.js'
-import Connection from './Connection.js'
 
 export enum MessageType {
   Unknown = -1,
@@ -16,8 +16,8 @@ export enum MessageType {
   SyncReply = 4, // same as Sync, but won't trigger another 'SyncStep1'
   Stateless = 5,
   BroadcastStateless = 6,
-
   CLOSE = 7,
+  SyncStatus = 8,
 }
 
 export interface AwarenessUpdate {

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@tiptap/pm": "^2.0.3",
     "y-prosemirror": "^1.0.15",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@tiptap/pm": "^2.0.3"

--- a/playground/backend/package.json
+++ b/playground/backend/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^9.0.0",
     "koa": "^2.13.4",
     "koa-easy-ws": "^1.3.1",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.1",

--- a/playground/frontend/package.json
+++ b/playground/frontend/package.json
@@ -19,7 +19,7 @@
     "vite-plugin-pages": "^0.29.0",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "typescript": "^5.0.4",

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "redis": "^4.0.4",
     "sinon": "^12.0.1",
     "ws": "^8.5.0",
-    "yjs": "^13.5.29"
+    "yjs": "^13.6.4"
   },
   "devDependencies": {
     "@types/redis": "^4.0.11",

--- a/tests/provider/hasUnsyncedChanges.ts
+++ b/tests/provider/hasUnsyncedChanges.ts
@@ -1,0 +1,187 @@
+import test from 'ava'
+import { retryableAssertion } from 'tests/utils/retryableAssertion'
+import * as Y from 'yjs'
+import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils'
+
+test("initially doesn't have unsynced changes", async t => {
+  return new Promise(async resolve => {
+
+    const server = await newHocuspocus()
+
+    const provider = newHocuspocusProvider(server)
+
+    t.is(provider.hasUnsyncedChanges, false)
+    t.is(provider.synced, false)
+
+    setTimeout(() => {
+      t.is(provider.hasUnsyncedChanges, false)
+      t.is(provider.synced, true)
+
+      resolve()
+    }, 100)
+  })
+})
+
+test('has unsynced changes when updating', async t => {
+  const server = await newHocuspocus()
+
+  const provider = newHocuspocusProvider(server, {
+    awareness: undefined,
+  })
+
+  provider.document.getMap('test').set('foo', 'bar')
+  t.is(provider.hasUnsyncedChanges, true)
+
+  // changes are synced
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, false)
+  })
+})
+
+test('has unsynced changes when in readonly mode', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const provider = newHocuspocusProvider(server, { token: 'readonly' })
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  // confirm that the changes are not synced later either
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has no unsynced changes when in readonly mode and no changes', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const provider = newHocuspocusProvider(server, { token: 'readonly' })
+
+  // first, unsyncedChanges is briefly set to true when we're waiting for the ack of the initial sync
+  await new Promise((resolve, reject) => {
+    provider.on('unsyncedChanges', () => {
+      provider.off('unsyncedChanges')
+      if (provider.hasUnsyncedChanges) {
+        resolve('done')
+      } else {
+        reject()
+      }
+    })
+  })
+
+  // then, it should be set to false when the sync message is confirmed
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, false)
+  })
+})
+
+test('has unsynced changes when in readonly mode and receiving external update', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection, token }) {
+      if (token === 'readonly') {
+        connection.readOnly = true
+      }
+    },
+  })
+
+  const provider = newHocuspocusProvider(server, {
+    token: 'readonly',
+  })
+
+  provider.document.getMap('test').set('foo', 'bar')
+
+  t.is(provider.hasUnsyncedChanges, true)
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+
+  const provider2 = newHocuspocusProvider(server, {
+    token: 'full-access',
+  })
+
+  provider2.document.getMap('test2').set('foo', 'bar')
+
+  t.is(provider2.hasUnsyncedChanges, true)
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider2.hasUnsyncedChanges, false)
+  })
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has unsynced changes when in readonly mode and initial document has changed', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has unsynced changes when in readonly mode and initial document has changed (deletion)', async t => {
+  const document = new Y.Doc()
+  document.getMap('test').set('foo', 'bar')
+  const initialState = Y.encodeStateAsUpdate(document)
+
+  const server = await newHocuspocus({
+    async onLoadDocument() {
+      return initialState
+    },
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  document.getMap('test').delete('foo')
+
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
+
+  await retryableAssertion(t, tt => {
+    tt.is(provider.hasUnsyncedChanges, true)
+  })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, true)
+})
+
+test('has no unsynced changes when in readonly mode and initial document has not changed', async t => {
+  const server = await newHocuspocus({
+    async onAuthenticate({ connection }) {
+      connection.readOnly = true
+    },
+  })
+
+  const document = new Y.Doc()
+
+  const provider = newHocuspocusProvider(server, { document, token: 'readonly' })
+
+  await sleep(100)
+
+  t.is(provider.hasUnsyncedChanges, false)
+})

--- a/tests/provider/onAwarenessChange.ts
+++ b/tests/provider/onAwarenessChange.ts
@@ -68,35 +68,48 @@ test('gets the current awareness states from the server', async t => {
 
     const provider = newHocuspocusProvider(server, {
       onSynced() {
-        t.deepEqual(server.getMessageLogs(), [
-          {
-            category: 'SyncStep1',
-            direction: 'in',
-            type: 'Sync',
-          },
-          {
-            category: 'SyncStep2',
-            direction: 'out',
-            type: 'Sync',
-          },
-          {
-            category: 'SyncStep1',
-            direction: 'out',
-            type: 'Sync',
-          },
-          {
-            category: 'Update',
-            direction: 'in',
-            type: 'Awareness',
-          },
-          {
-            category: 'Update',
-            direction: 'out',
-            type: 'Awareness',
-          },
-        ])
+        setTimeout(() => {
 
-        resolve('done')
+          t.deepEqual(server.getMessageLogs(), [
+            {
+              category: 'SyncStep1',
+              direction: 'in',
+              type: 'Sync',
+            },
+            {
+              category: 'SyncStep2',
+              direction: 'out',
+              type: 'Sync',
+            },
+            {
+              category: 'SyncStep1',
+              direction: 'out',
+              type: 'Sync',
+            },
+            {
+              category: 'Update',
+              direction: 'in',
+              type: 'Awareness',
+            },
+            {
+              category: 'Update',
+              direction: 'out',
+              type: 'Awareness',
+            },
+            {
+              category: 'Update',
+              direction: 'in',
+              type: 'Awareness',
+            },
+            {
+              category: 'SyncStep2',
+              direction: 'in',
+              type: 'Sync',
+            },
+          ])
+
+          resolve('done')
+        }, 100)
       },
     })
 

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -241,7 +241,7 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
 
 test('if a new connection connects while the previous connection still fetches the document, it will just work properly', async t => {
   let callsToOnLoadDocument = 0
-  const resolvesNeeded = 7
+  const resolvesNeeded = 11
 
   await new Promise(async resolve => {
 
@@ -289,6 +289,10 @@ test('if a new connection connects while the previous connection still fetches t
         const value = provider.document.getArray('foo').get(0)
 
         if (provider1MessagesReceived === 1) {
+          // do nothing, this is just the ACK for the sync
+        } else if (provider1MessagesReceived === 2) {
+          // do nothing, this is just the ACK for the received update (set "bar-updatedAfterProvider1Synced")
+        } else if (provider1MessagesReceived === 3) {
           t.is(value, 'bar-updatedAfterProvider1Synced')
         } else {
           t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
@@ -318,8 +322,12 @@ test('if a new connection connects while the previous connection still fetches t
           const value = provider.document.getArray('foo').get(0)
 
           if (provider2MessagesReceived === 1) {
+            // do nothing, this is just the ACK for the sync
             t.is(value, undefined)
           } else if (provider2MessagesReceived === 2) {
+            // initial state is now synced
+            t.is(value, undefined)
+          } else if (provider2MessagesReceived === 3) {
             t.is(value, 'bar-updatedAfterProvider1Synced')
             setTimeout(() => {
               provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])


### PR DESCRIPTION
This adds an improved way of figuring out if the document is fully synced with the server.

WARNING: You should update @hocuspocus/server before upgrading the client. "hasUnsyncedChanges" of @hocuspocus/provider 2.3.0 is NOT compatible with @hocuspocus/server <2.3.0. If you upgrade the server while running provider <2.2.3, the provider will show errors in the browser, which can be safely ignored. If you dont want to see errors, upgrade the provider to v2.2.3 first, then upgrade the server to 2.3.0, and then upgrade the provider again. Or just upgrade everything simultaneously to 2.3.0.

This is basically #635 by @YousefED, just adjusted to merge with dc5990ddbec249cd575e214f7b95828df284a795