### PR TITLE
afterUnloadDocument hook

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -155,7 +155,7 @@ export class Redis implements Extension {
   }
 
   /**
-   * Once a document is laoded, subscribe to the channel in Redis.
+   * Once a document is loaded, subscribe to the channel in Redis.
    */
   public async afterLoadDocument({ documentName, document }: afterLoadDocumentPayload) {
     return new Promise((resolve, reject) => {

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -1,4 +1,5 @@
 import { IncomingHttpHeaders, IncomingMessage } from 'http'
+import { URLSearchParams } from 'url'
 import {
   Forbidden, Unauthorized, WsReadyStates,
 } from '@hocuspocus/common'

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -33,25 +33,26 @@ export interface ConnectionConfiguration {
 }
 
 export interface Extension {
-  priority?: number,
-  onConfigure?(data: onConfigurePayload): Promise<any>,
-  onListen?(data: onListenPayload): Promise<any>,
-  onUpgrade?(data: onUpgradePayload): Promise<any>,
-  onConnect?(data: onConnectPayload): Promise<any>,
-  connected?(data: connectedPayload): Promise<any>,
-  onAuthenticate?(data: onAuthenticatePayload): Promise<any>,
-  onLoadDocument?(data: onLoadDocumentPayload): Promise<any>,
-  afterLoadDocument?(data: onLoadDocumentPayload): Promise<any>,
-  beforeHandleMessage?(data: beforeHandleMessagePayload): Promise<any>,
-  beforeBroadcastStateless?(data: beforeBroadcastStatelessPayload): Promise<any>,
+  priority?: number;
+  onConfigure?(data: onConfigurePayload): Promise<any>;
+  onListen?(data: onListenPayload): Promise<any>;
+  onUpgrade?(data: onUpgradePayload): Promise<any>;
+  onConnect?(data: onConnectPayload): Promise<any>;
+  connected?(data: connectedPayload): Promise<any>;
+  onAuthenticate?(data: onAuthenticatePayload): Promise<any>;
+  onLoadDocument?(data: onLoadDocumentPayload): Promise<any>;
+  afterLoadDocument?(data: onLoadDocumentPayload): Promise<any>;
+  beforeHandleMessage?(data: beforeHandleMessagePayload): Promise<any>;
+  beforeBroadcastStateless?(data: beforeBroadcastStatelessPayload): Promise<any>;
   onStateless?(payload: onStatelessPayload): Promise<any>;
-  onChange?(data: onChangePayload): Promise<any>,
-  onStoreDocument?(data: onStoreDocumentPayload): Promise<any>,
-  afterStoreDocument?(data: afterStoreDocumentPayload): Promise<any>,
-  onAwarenessUpdate?(data: onAwarenessUpdatePayload): Promise<any>,
-  onRequest?(data: onRequestPayload): Promise<any>,
-  onDisconnect?(data: onDisconnectPayload): Promise<any>
-  onDestroy?(data: onDestroyPayload): Promise<any>,
+  onChange?(data: onChangePayload): Promise<any>;
+  onStoreDocument?(data: onStoreDocumentPayload): Promise<any>;
+  afterStoreDocument?(data: afterStoreDocumentPayload): Promise<any>;
+  onAwarenessUpdate?(data: onAwarenessUpdatePayload): Promise<any>;
+  onRequest?(data: onRequestPayload): Promise<any>;
+  onDisconnect?(data: onDisconnectPayload): Promise<any>;
+  afterUnloadDocument?(data: onLoadDocumentPayload): Promise<any>;
+  onDestroy?(data: onDestroyPayload): Promise<any>;
 }
 
 export type HookName =
@@ -72,27 +73,30 @@ export type HookName =
   'onAwarenessUpdate' |
   'onRequest' |
   'onDisconnect' |
+  'afterUnloadDocument' |
   'onDestroy'
 
-export type HookPayload =
-  onConfigurePayload |
-  onListenPayload |
-  onUpgradePayload |
-  onConnectPayload |
-  connectedPayload |
-  onAuthenticatePayload |
-  onLoadDocumentPayload |
-  onStatelessPayload |
-  beforeHandleMessagePayload |
-  beforeBroadcastStatelessPayload |
-  onChangePayload |
-  onStoreDocumentPayload |
-  afterStoreDocumentPayload |
-  onAwarenessUpdatePayload |
-  onRequestPayload |
-  onDisconnectPayload |
-  onDestroyPayload
-
+export type HookPayloadByName = {
+  onConfigure: onConfigurePayload,
+  onListen: onListenPayload,
+  onUpgrade: onUpgradePayload,
+  onConnect: onConnectPayload,
+  connected: connectedPayload,
+  onAuthenticate: onAuthenticatePayload,
+  onLoadDocument: onLoadDocumentPayload,
+  afterLoadDocument: onLoadDocumentPayload,
+  beforeHandleMessage: beforeHandleMessagePayload,
+  beforeBroadcastStateless: beforeBroadcastStatelessPayload,
+  onStateless: onStatelessPayload,
+  onChange: onChangePayload,
+  onStoreDocument: onStoreDocumentPayload,
+  afterStoreDocument: afterStoreDocumentPayload,
+  onAwarenessUpdate: onAwarenessUpdatePayload,
+  onRequest: onRequestPayload,
+  onDisconnect: onDisconnectPayload,
+  afterUnloadDocument: afterUnloadDocumentPayload,
+  onDestroy: onDestroyPayload,
+}
 export interface Configuration extends Extension {
   /**
    * A name for the instance, used for logging.
@@ -263,14 +267,12 @@ export interface onStoreDocumentPayload {
 export interface afterStoreDocumentPayload extends onStoreDocumentPayload {}
 
 export interface onAwarenessUpdatePayload {
-  clientsCount: number,
   context: any,
   document: Document,
   documentName: string,
   instance: Hocuspocus,
   requestHeaders: IncomingHttpHeaders,
   requestParameters: URLSearchParams,
-  update: Uint8Array,
   socketId: string,
   added: number[],
   updated: number[],
@@ -336,6 +338,11 @@ export interface onConfigurePayload {
   instance: Hocuspocus,
   configuration: Configuration,
   version: string,
+}
+
+export interface afterUnloadDocumentPayload {
+  instance: Hocuspocus;
+  documentName: string;
 }
 
 export interface DirectConnection {

--- a/tests/server/afterUnloadDocument.ts
+++ b/tests/server/afterUnloadDocument.ts
@@ -1,0 +1,53 @@
+import test from 'ava'
+import { HocuspocusProvider } from '@hocuspocus/provider'
+
+import { newHocuspocus, newHocuspocusProvider } from '../utils/index.js'
+
+test('executes the afterUnloadDocument callback when all clients disconnect after a document was loaded', async t => {
+  await new Promise(async resolve => {
+    let provider: HocuspocusProvider
+
+    class CustomExtension {
+      async afterLoadDocument() {
+        provider.configuration.websocketProvider.disconnect()
+        provider.disconnect()
+      }
+
+      async afterUnloadDocument() {
+        t.pass()
+        resolve('done')
+      }
+    }
+
+    const server = await newHocuspocus({
+      extensions: [new CustomExtension()],
+    })
+
+    provider = newHocuspocusProvider(server)
+  })
+})
+
+test('executes the afterUnloadDocument callback when document fails to load', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus()
+
+    class CustomExtension {
+      async onLoadDocument() {
+        throw new Error('oops!')
+      }
+
+      async afterUnloadDocument() {
+        t.pass()
+        resolve('done')
+      }
+    }
+
+    server.configure({
+      extensions: [
+        new CustomExtension(),
+      ],
+    })
+
+    newHocuspocusProvider(server)
+  })
+})


### PR DESCRIPTION
This PR adds an `afterUnloadDocument` hook that runs whenever a previously loaded document is removed by the server, for any reason.

The motivation for adding this feature is because I monitor documents being opened and closed in a load balancer that speaks to an extension and I noticed the load balancer was not removing all documents for some reason when I listen to it like this:

```ts
{
  async afterLoadDocument({
    documentName,
  }: onLoadDocumentPayload): Promise<void> {
   addToLoadBalancer(documentName);
  }

  async onDisconnect({
    documentName,
    clientsCount,
  }: onDisconnectPayload): Promise<void> {
    if (clientsCount === 0) {
      removeFromLoadBalancer(documentName);
    }
  }
}
```

I also fixed up the type of the `hooks` function so that you can no longer pass an incorrect payload that does not match the exact one for that hook specified in the types. There were a couple of cases where they didn't match and I had to fix those. This was to prevent issues such as https://github.com/ueberdosis/hocuspocus/pull/641 in the future.