### PR TITLE
fix: remove awareness stats on page unload instead of beforeunload

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -209,7 +209,7 @@ export class HocuspocusProvider extends EventEmitter {
 
   boundBroadcastChannelSubscriber = this.broadcastChannelSubscriber.bind(this)
 
-  boundBeforeUnload = this.beforeUnload.bind(this)
+  boundPageUnload = this.pageUnload.bind(this)
 
   boundOnOpen = this.onOpen.bind(this)
 
@@ -278,7 +278,7 @@ export class HocuspocusProvider extends EventEmitter {
     this.send(SyncStepOneMessage, { document: this.document, documentName: this.configuration.name })
   }
 
-  beforeUnload() {
+  pageUnload() {
     removeAwarenessStates(this.awareness, [this.document.clientID], 'window unload')
   }
 
@@ -287,7 +287,7 @@ export class HocuspocusProvider extends EventEmitter {
       return
     }
 
-    window.addEventListener('beforeunload', this.boundBeforeUnload)
+    window.addEventListener('unload', this.boundPageUnload)
   }
 
   sendStateless(payload: string) {
@@ -468,7 +468,7 @@ export class HocuspocusProvider extends EventEmitter {
       return
     }
 
-    window.removeEventListener('beforeunload', this.boundBeforeUnload)
+    window.removeEventListener('unload', this.boundPageUnload)
   }
 
   permissionDeniedHandler(reason: string) {


### PR DESCRIPTION
I notice the code in file `packages/provider/src/HocuspocusProvider.ts`
```typescript
window.addEventListener('beforeunload', this.boundBeforeUnload)
```
I must say that what if I prevent the page to be close? consider this logic below
```typescript
// https://developer.mozilla.org/en/docs/Web/API/Window/beforeunload_event
window.addEventListener('beforeunload', (event) => {
  event.preventDefault()
  event.returnValue = ''
})
```
Develop can write intercept logic and users may cancel to close this page.