### PR TITLE
Fix/doc links

### DIFF
--- a/docs/links.yaml
+++ b/docs/links.yaml
@@ -13,7 +13,7 @@
 - title: Server
   items:
     - title: Cloud
-      link: /../cloud
+      link: /cloud
       type: new
     - title: Configuration
       link: /server/configuration

--- a/docs/server/hooks.md
+++ b/docs/server/hooks.md
@@ -8,7 +8,7 @@ tableOfContents: true
 
 Hocuspocus offers hooks to extend it's functionality and integrate it into existing applications. Hooks are configured as simple methods the same way as [other configuration options](/server/configuration) are.
 
-Hooks accept a hook payload as first argument. The payload is an object that contains data you can use and manipulate, allowing you to built complex things on top of this simple mechanic, like [extensions](/guides/custom-extension).
+Hooks accept a hook payload as first argument. The payload is an object that contains data you can use and manipulate, allowing you to built complex things on top of this simple mechanic, like [extensions](/guides/custom-extensions).
 
 Hooks are required to return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), the easiest way to do that is to mark the function as `async` (Node.js version must 14+). In this way, you can do things like executing API requests, running DB queries, trigger webhooks or whatever you need to do to integrate it into your application.
 


### PR DESCRIPTION
I have fixed the link "Cloud" in the navigation to "/hocuspocus/../cloud". It work's because of the tolerance of the browsers, but we get an error in our broken link checker 😉

The checker also reported a broken link on this page: https://tiptap.dev/hocuspocus/server/hooks. The link in the sentence "... allowing you to built complex things on top of this simple mechanic, like **extensions**." points to a 404 page because of the missing S at the end of the link to: https://tiptap.dev/hocuspocus/guides/custom-extension