### PR TITLE
fix: check if ymap is empty

### DIFF
--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -57,7 +57,7 @@ export class Document extends Doc {
    */
   isEmpty(fieldName: string): boolean {
     // eslint-disable-next-line no-underscore-dangle
-    return !this.get(fieldName)._start || !this.get(fieldName)._map.size
+    return !this.get(fieldName)._start && !this.get(fieldName)._map.size
   }
 
   /**

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -53,11 +53,11 @@ export class Document extends Doc {
   }
 
   /**
-   * Check if the Document is empty
+   * Check if the Document (XMLFragment or Map) is empty
    */
   isEmpty(fieldName: string): boolean {
     // eslint-disable-next-line no-underscore-dangle
-    return !this.get(fieldName)._start
+    return !this.get(fieldName)._start || !this.get(fieldName)._map.size
   }
 
   /**


### PR DESCRIPTION
Hello everything is fine?

I'm doing this mini adjustment to support the presence check of the YMap, in it the _start is null despite having some value.

Please feel free to say whether or not this makes sense.

Debbug:
![Captura de tela de 2023-07-31 20-43-00](https://github.com/ueberdosis/hocuspocus/assets/43552865/4c6f8cde-0894-43d4-9b32-5bcf06bc1ad0)

![image](https://github.com/ueberdosis/hocuspocus/assets/43552865/0c07b975-7743-4ebe-8ca6-6aa735c67b79)
