### PR TITLE
throw error in onStoreDocument to prevent afterStoreDocument from releasing lock

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -546,14 +546,9 @@ export class Hocuspocus {
 
   storeDocumentHooks(document: Document, hookPayload: onStoreDocumentPayload) {
     this.hooks('onStoreDocument', hookPayload)
-      .catch(error => {
-        if (error?.message) {
-          throw error
-        }
-      })
       .then(() => {
         this.hooks('afterStoreDocument', hookPayload).then(() => {
-        // Remove document from memory.
+          // Remove document from memory.
 
           if (document.getConnectionsCount() > 0) {
             return
@@ -561,6 +556,13 @@ export class Hocuspocus {
 
           this.unloadDocument(document)
         })
+      })
+      .catch(error => {
+        console.error('Caught error during storeDocumentHooks', error)
+
+        if (error?.message) {
+          throw error
+        }
       })
   }
 

--- a/tests/server/onStoreDocument.ts
+++ b/tests/server/onStoreDocument.ts
@@ -252,12 +252,7 @@ test('runs hooks in the given order', async t => {
         triggered.push('four')
       },
       async afterStoreDocument() {
-        t.deepEqual(triggered, [
-          'one',
-          'two',
-        ])
-
-        resolve('done')
+        t.fail() // this shouldnt run
       },
     })
 
@@ -265,6 +260,15 @@ test('runs hooks in the given order', async t => {
       onSynced() {
         provider.configuration.websocketProvider.destroy()
         provider.destroy()
+
+        setTimeout(() => {
+          t.deepEqual(triggered, [
+            'one',
+            'two',
+          ])
+
+          resolve(true)
+        }, 250)
       },
     })
   })
@@ -303,13 +307,7 @@ test('allows to overwrite the order of extension with a priority', async t => {
 
     const server = await newHocuspocus({
       afterStoreDocument: async () => {
-        t.deepEqual(triggered, [
-          'zero',
-          'one',
-          'two',
-        ])
-
-        resolve('done')
+        t.fail()
       },
       extensions: [
         new Running(),
@@ -323,6 +321,16 @@ test('allows to overwrite the order of extension with a priority', async t => {
       onSynced() {
         provider.configuration.websocketProvider.destroy()
         provider.destroy()
+
+        setTimeout(() => {
+          t.deepEqual(triggered, [
+            'zero',
+            'one',
+            'two',
+          ])
+
+          resolve(true)
+        }, 250)
       },
     })
   })


### PR DESCRIPTION
*Note: This scenario occurs when using the `redis-extension`.*

Upon an initial write, we acquire a redis lock in the `onStoreDocument` hook to prevent multiple writes from colliding with each other.
On subsequent writes, if no error is thrown in `onStoreDocument` hook in `redis-extension` (due to a lock being held already), then `afterStoreDocument` will be called for the server. `afterStoreDocument` will release the lock for that subsequent write, which opens up the flood gates for writes to pile up, essentially DDOSing the datastore.

Code where `error` is always null so it never re-throws.
https://github.com/ueberdosis/hocuspocus/blob/4160dd7b93147787e6524dccd57e9012fc065d0d/packages/server/src/Hocuspocus.ts#L549-L555