### PR TITLE
Linear time mux

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -71,15 +71,12 @@ export class Connection {
     this.pingInterval = setInterval(this.check.bind(this), this.timeout)
 
     this.webSocket.on('close', this.boundClose)
-    this.webSocket.on('message', this.boundHandleMessage)
     this.webSocket.on('pong', this.boundHandlePong)
 
     this.sendCurrentAwareness()
   }
 
   boundClose = this.close.bind(this)
-
-  boundHandleMessage = this.handleMessage.bind(this)
 
   boundHandlePong = this.handlePong.bind(this)
 
@@ -167,7 +164,6 @@ export class Connection {
       }
 
       this.webSocket.removeListener('close', this.boundClose)
-      this.webSocket.removeListener('message', this.boundHandleMessage)
       this.webSocket.removeListener('pong', this.boundHandlePong)
 
       done()
@@ -217,9 +213,9 @@ export class Connection {
 
   /**
    * Handle an incoming message
-   * @private
+   * @public
    */
-  private handleMessage(data: Uint8Array): void {
+  public handleMessage(data: Uint8Array): void {
     const message = new IncomingMessage(data)
     const documentName = message.readVarString()
 


### PR DESCRIPTION
Reduces the amount of work needed to ignore irrelevant messages due to documentName mux/demux from O(n^2) to O(n).

When just a few documents are muxed over the same websocket, the extra work done by the `on('message')` handler in each Connection is not noticable. However, when a single websocket carries messages for dozens or hundreds of documents, the work done by each Connection to discover the documentName becomes ~~exponential~~ quadratic, causing slowdown and potential crashes.