### PR TITLE
Lazily createEncoder for IncomingMessage

### DIFF
--- a/packages/server/src/IncomingMessage.ts
+++ b/packages/server/src/IncomingMessage.ts
@@ -22,7 +22,9 @@ export class IncomingMessage {
   decoder: Decoder
 
   /**
-   * Access to the reply.
+   * Private encoder; can be undefined.
+   *
+   * Lazy creation of the encoder speeds up IncomingMessages that need only a decoder.
    */
   private encoderInternal?: Encoder
 

--- a/packages/server/src/IncomingMessage.ts
+++ b/packages/server/src/IncomingMessage.ts
@@ -24,15 +24,21 @@ export class IncomingMessage {
   /**
    * Access to the reply.
    */
-  encoder: Encoder
+  private encoderInternal?: Encoder
 
   constructor(input: any) {
     if (!(input instanceof Uint8Array)) {
       input = new Uint8Array(input)
     }
 
-    this.encoder = createEncoder()
     this.decoder = createDecoder(input)
+  }
+
+  get encoder() {
+    if (!this.encoderInternal) {
+      this.encoderInternal = createEncoder()
+    }
+    return this.encoderInternal
   }
 
   readVarUint8Array() {


### PR DESCRIPTION
Approximately 2/3 of the initialization time of `new IncomingMessage` is taken by the `createEncoder` call within IncomingMessage's constructor.

The vast majority of IncomingMessage usage is to decode the incoming message first to determine if it is relevant--e.g. to determine what document it belongs to, and what type of message it is.

This change improves performance by avoiding the `createEncoder` call until we know it is actually necessary.