### PR TITLE
Allow provider awareness to be disabled

### DIFF
--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -98,8 +98,6 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     url: '',
     // @ts-ignore
     document: undefined,
-    // @ts-ignore
-    awareness: undefined,
     WebSocketPolyfill: undefined,
     parameters: {},
     connect: true,
@@ -369,7 +367,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     }
 
     // No message received in a long time, not even your own
-    // Awareness updates, which are updated every 15 seconds.
+    // Awareness updates, which are updated every 15 seconds
+    // if awareness is enabled.
     this.closeTries += 1
     // https://bugs.webkit.org/show_bug.cgi?id=247943
     if (this.closeTries > 2) {

--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -97,6 +97,8 @@ export class MessageReceiver {
   }
 
   private applyAwarenessMessage(provider: HocuspocusProvider) {
+    if (!provider.awareness) return
+
     const { message } = this
 
     awarenessProtocol.applyAwarenessUpdate(
@@ -117,6 +119,8 @@ export class MessageReceiver {
   }
 
   private applyQueryAwarenessMessage(provider: HocuspocusProvider) {
+    if (!provider.awareness) return
+
     const { message } = this
 
     message.writeVarUint(MessageType.Awareness)

--- a/tests/provider/onAwarenessUpdate.ts
+++ b/tests/provider/onAwarenessUpdate.ts
@@ -1,4 +1,5 @@
 import test from 'ava'
+import { AwarenessError } from '@hocuspocus/provider'
 import { newHocuspocus, newHocuspocusProvider, sleep } from '../utils/index.js'
 
 test('onAwarenessUpdate callback is executed', async t => {
@@ -76,6 +77,46 @@ test('does not share awareness state with users in other documents', async t => 
       name: 'hocuspocus-completly-different-and-unrelated-document',
       onConnect() {
         anotherProvider.setAwarenessField('name', 'player2')
+      },
+    })
+  })
+})
+
+test('allows awareness to be null', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({ })
+
+    newHocuspocusProvider(server, {
+      awareness: null,
+      async onConnect() {
+        await sleep(100)
+
+        t.pass()
+        resolve('done')
+      },
+    })
+  })
+})
+
+test('throws an error in setAwarenessFields if awareness is null', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus()
+
+    const provider = newHocuspocusProvider(server, {
+      awareness: null,
+      onConnect() {
+        try {
+          provider.setAwarenessField('foo', 'bar')
+          t.fail()
+        } catch (err: any) {
+          if (err instanceof AwarenessError) {
+            t.pass()
+          } else {
+            t.fail()
+          }
+        } finally {
+          resolve('done')
+        }
       },
     })
   })


### PR DESCRIPTION
Fixes https://github.com/ueberdosis/hocuspocus/discussions/673

Awareness provides an additional overhead of computation, memory, and network usage for each provider. This can become significant when there are hundreds of documents that are multiplexed through a single websocket connection.

This PR allows users to opt-out of the provider's default Awareness instance by specifying `awareness: null` in the config.

If awareness is disabled...

- The Awareness instance will not be instantiated and AwarenessMessages will not be sent to the server.
- `setAwarenessField` will throw an error.
- AwarenessMessages from the server will be ignored.

Open to feedback, and will add documentation if approved :)