### PR TITLE
onChange should update instead of sync

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -290,7 +290,12 @@ export class Redis implements Extension {
    * if the ydoc changed, we'll need to inform other Hocuspocus servers about it.
    */
   public async onChange(data: onChangePayload): Promise<any> {
-    return this.publishFirstSyncStep(data.documentName, data.document)
+    const { documentName } = data
+    const updateMessage = new OutgoingMessage(documentName)
+      .createSyncMessage()
+      .writeUpdate(data.update)
+
+    return this.pub.publishBuffer(this.pubKey(documentName), Buffer.from(updateMessage.toUint8Array()))
   }
 
   /**


### PR DESCRIPTION
When a document changes, the Redis extension performs a full re-sync exchange with every single other server in the cluster. This is way more expensive than just sending an update.