### PR TITLE
make immediate unload optional

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -41,6 +41,7 @@ export const defaultConfiguration = {
     gc: true,
     gcFilter: () => true,
   },
+  unloadImmediately: true,
 }
 
 /**
@@ -323,13 +324,13 @@ export class Hocuspocus {
 
       // If it’s the last connection, we need to make sure to store the
       // document. Use the debounce helper, to clear running timers,
-      // but make it run immediately (`true`).
+      // but make it run immediately if configured.
       // Only run this if the document has finished loading earlier (i.e. not to persist the empty
       // ydoc if the onLoadDocument hook returned an error)
       if (!document.isLoading) {
         this.debounce(`onStoreDocument-${document.name}`, () => {
           this.storeDocumentHooks(document, hookPayload)
-        }, true)
+        }, this.configuration.unloadImmediately)
       } else {
         // Remove document from memory immediately
         this.unloadDocument(document)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -152,7 +152,7 @@ export interface Configuration extends Extension {
    * Function which returns the (customized) document name based on the request
    */
   getDocumentName?(data: getDocumentNamePayload): string | Promise<string>,
-  
+
 }
 
 export interface getDocumentNamePayload {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -132,6 +132,14 @@ export interface Configuration extends Extension {
    * By default, the servers show a start screen. If passed false, the server will start quietly.
    */
   quiet: boolean,
+  /**
+   * If set to false, respects the debounce time of `onStoreDocument` before unloading a document.
+   * Otherwise, the document will be unloaded immediately.
+   *
+   * This prevents a client from DOSing the server by repeatedly connecting and disconnecting when
+   * your onStoreDocument is rate-limited.
+   */
+  unloadImmediately: boolean,
 
   /**
    * options to pass to the ydoc document
@@ -144,6 +152,7 @@ export interface Configuration extends Extension {
    * Function which returns the (customized) document name based on the request
    */
   getDocumentName?(data: getDocumentNamePayload): string | Promise<string>,
+  
 }
 
 export interface getDocumentNamePayload {

--- a/tests/server/onStoreDocument.ts
+++ b/tests/server/onStoreDocument.ts
@@ -375,3 +375,34 @@ test('if a connection connects while another disconnects onStoreDocument is stil
   })
 
 })
+
+test('waits before calling onStoreDocument after the last user disconnects when configured', async t => {
+  await new Promise(async resolve => {
+    let startTime = 0
+    const server = await newHocuspocus({
+      unloadImmediately: false,
+      debounce: 500,
+      async onStoreDocument() {
+        const endTime = Date.now()
+        if (startTime === 0) {
+          t.fail('startTime not set')
+        } else if (endTime - startTime < 500) {
+          t.fail('did not wait 500ms to call onStoreDocument when closing')
+        } else {
+          t.pass()
+        }
+        resolve('done')
+      },
+    })
+
+    const socket = newHocuspocusProviderWebsocket(server);
+
+    const provider = newHocuspocusProvider(server, {
+      websocketProvider: socket,
+      onSynced() {
+        startTime = Date.now()
+        socket.destroy()
+      },
+    })
+  })
+})

--- a/tests/server/onStoreDocument.ts
+++ b/tests/server/onStoreDocument.ts
@@ -395,7 +395,7 @@ test('waits before calling onStoreDocument after the last user disconnects when 
       },
     })
 
-    const socket = newHocuspocusProviderWebsocket(server);
+    const socket = newHocuspocusProviderWebsocket(server)
 
     const provider = newHocuspocusProvider(server, {
       websocketProvider: socket,


### PR DESCRIPTION
Currently the debounce argument used to debounce `onStoreDocument` is ignored when the last client for a document disconnects.

However if your `onStoreDocument` call is rate limited this means that a client can DOS your server by repeatedly opening and closing a document, preventing storage of it.

From what I can see we don't actually need to run this immediately as the unload happens after `onStoreDocument` only if there are still no connections.