### PR TITLE
Reset last message received when creating new socket

### DIFF
--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -296,6 +296,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
         this.webSocket.close()
         this.webSocket = null
       }
+      this.lastMessageReceived = 0
 
       // Init the WebSocket connection
       const ws = new this.configuration.WebSocketPolyfill(this.url)


### PR DESCRIPTION
Currently we dont reset the last message recieved when connecting a new socket, which can potentially cause disconnection on a socket thats in the process of connecting.
If we reset the last message received on new websocket, it will consequently wait for message on this new ws before closing