### PR TITLE
Update Redis extension docs

### DIFF
--- a/docs/server/extensions.md
+++ b/docs/server/extensions.md
@@ -178,6 +178,8 @@ Hocuspocus can be scaled horizontally using the Redis extension. You can spawn m
 load balancer and sync changes and awareness states through Redis. Hocuspocus will propagate all received updates to all other instances
 using Redis and thus forward updates to all clients of all Hocuspocus instances.
 
+The Redis extension does not persist data; it only syncs data between instances. Use the [Database](/server/extensions#database) extension to store your documents.
+
 Please note that all messages will be handled on all instances of Hocuspocus, so if you are trying to reduce cpu load by spawning multiple
 servers, you should not connect them via Redis.
 


### PR DESCRIPTION
Updates the Redis extension docs to mention that the extension does not persist documents.

Related: #440