### PR TITLE
Fix typos and unnecessary gendered language

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -12,7 +12,7 @@ With the `onAuthenticate` hook you can check if a client is authenticated and au
 
 When throwing an error or rejecting the returned Promise, the connection to the client will be terminated (see [server hooks lifecycle](/server/hooks#lifecycle)). If the client is authorized and authenticated you can also return contextual data such as a user id which will be accessible in other hooks. But you don’t need to.
 
-For more information on the hook and it's payload checkout it's [section](/server/hooks#on-authenticate).
+For more information on the hook and its payload, check out its [section](/server/hooks#on-authenticate).
 
 ```js
 import { Server } from "@hocuspocus/server";
@@ -52,8 +52,8 @@ new HocuspocusProvider({
 
 ## Read only mode
 
-If you want to restrict the current user only to read the document and it's updates but not apply
-updates him- or herself, you can use the `connection` property in the `onAuthenticate` hooks payload:
+If you want to restrict the current user only to read the document and its updates but not apply
+updates themselves, you can use the `connection` property in the `onAuthenticate` hooks payload:
 
 ```js
 import { Server } from "@hocuspocus/server";

--- a/docs/server/examples.md
+++ b/docs/server/examples.md
@@ -21,7 +21,7 @@ npx @hocuspocus/cli --sqlite
 
 ### Express
 
-Hocuspocus can be used with any WebSocket implementation that uses `ws` under the hood. When you don't call `listen()` on Hocuspocus, it will not start a WebSocket server itself but rather relies on you calling it's [`handleConnection()` method](/server/methods) manually.
+Hocuspocus can be used with any WebSocket implementation that uses `ws` under the hood. When you don't call `listen()` on Hocuspocus, it will not start a WebSocket server itself but rather relies on you calling its [`handleConnection()` method](/server/methods) manually.
 
 To use Hocuspocus with [Express](https://expressjs.com), you need to use the `express-ws` package that adds WebSocket endpoints to Express applications. Then add a new WebSocket route and use Hocuspocus' `handleConnection()` method to do the rest.
 

--- a/docs/server/hooks.md
+++ b/docs/server/hooks.md
@@ -6,11 +6,11 @@ tableOfContents: true
 
 ## Introduction
 
-Hocuspocus offers hooks to extend it's functionality and integrate it into existing applications. Hooks are configured as simple methods the same way as [other configuration options](/server/configuration) are.
+Hocuspocus offers hooks to extend its functionality and integrate it into existing applications. Hooks are configured as simple methods the same way as [other configuration options](/server/configuration) are.
 
 Hooks accept a hook payload as first argument. The payload is an object that contains data you can use and manipulate, allowing you to built complex things on top of this simple mechanic, like [extensions](/guides/custom-extensions).
 
-Hooks are required to return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), the easiest way to do that is to mark the function as `async` (Node.js version must 14+). In this way, you can do things like executing API requests, running DB queries, trigger webhooks or whatever you need to do to integrate it into your application.
+Hooks are required to return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise); the easiest way to do that is to mark the function as `async` (Node.js version must 14+). In this way, you can do things like executing API requests, running DB queries, trigger webhooks or whatever you need to do to integrate it into your application.
 
 ## Lifecycle
 
@@ -20,7 +20,7 @@ Some hooks allow you not only to react to those events but also to intercept the
 
 ## The hook chain
 
-Extensions use hooks to add additional functionality to Hocuspocus. They will be called after another in the order of their registration with your configuration as the last part of the chain.
+Extensions use hooks to add additional functionality to Hocuspocus. They will be called one after another in the order of their registration with your configuration as the last part of the chain.
 
 If the Promise in a hook is rejected it will not be called for the following extensions or your configuration. It's like a stack of middlewares a request has to go through. Keep that in mind when working with hooks.
 
@@ -608,7 +608,7 @@ Context contains the data provided in former `onConnect` hooks.
 
 ### afterLoadDocument
 
-The `afterLoadDocument` hooks are called after a document is successfully loaded. This is different 
+The `afterLoadDocument` hooks are called after a document is successfully loaded. This is different
 to the `onLoadDocument` hooks which are part of the document creation process and could potentially
 fail if for instance the document cannot be found in the database.
 


### PR DESCRIPTION
I noticed an ungainly and unnecessary usage of gendered language on the auth docs page. This PR replaces the gendered construct with the gramatically correct "...apply updates themselves," in addition to fixing some other minor issues on this and other pages.

The main other change this PR makes is to fix incorrect uses of the contractive "it's" in places where the possessive "its" should instead be used.