### PR TITLE
extension-redis: fixes a bug that caused document updates to cause an…

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -84,6 +84,8 @@ export class Redis implements Extension {
     disconnectDelay: 1000,
   }
 
+  redisTransactionOrigin = '__hocuspocus__redis__origin__'
+
   pub: RedisInstance
 
   sub: RedisInstance
@@ -295,6 +297,7 @@ export class Redis implements Extension {
     new MessageReceiver(
       message,
       this.logger,
+      this.redisTransactionOrigin,
     ).apply(document, undefined, reply => {
       return this.pub.publishBuffer(
         this.pubKey(document.name),
@@ -307,7 +310,9 @@ export class Redis implements Extension {
    * if the ydoc changed, we'll need to inform other Hocuspocus servers about it.
    */
   public async onChange(data: onChangePayload): Promise<any> {
-    return this.publishFirstSyncStep(data.documentName, data.document)
+    if (data.transactionOrigin !== this.redisTransactionOrigin) {
+      return this.publishFirstSyncStep(data.documentName, data.document)
+    }
   }
 
   /**

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -23,9 +23,12 @@ export class MessageReceiver {
 
   logger: Debugger
 
-  constructor(message: IncomingMessage, logger: Debugger) {
+  defaultTransactionOrigin?: string
+
+  constructor(message: IncomingMessage, logger: Debugger, defaultTransactionOrigin?: string) {
     this.message = message
     this.logger = logger
+    this.defaultTransactionOrigin = defaultTransactionOrigin
   }
 
   public apply(document: Document, connection?: Connection, reply?: (message: Uint8Array) => void) {
@@ -179,7 +182,7 @@ export class MessageReceiver {
           break
         }
 
-        readSyncStep2(message.decoder, document, connection)
+        readSyncStep2(message.decoder, document, connection ?? this.defaultTransactionOrigin)
 
         if (connection) {
           connection.send(new OutgoingMessage(document.name)


### PR DESCRIPTION
When applying an update incoming via redis, we unexpectedly triggered `onChange`, which then triggered another full sync. This caused eight messages to be exchanged via redis per change. With this fix merged, it will be just four.