### PR TITLE
Fix multiple sockets on reconnection

### DIFF
--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -7,6 +7,7 @@ import * as time from 'lib0/time'
 import * as url from 'lib0/url'
 import type { MessageEvent } from 'ws'
 import { Event } from 'ws'
+import { uuidv4 } from 'lib0/random.js'
 import EventEmitter from './EventEmitter.js'
 import { HocuspocusProvider } from './HocuspocusProvider.js'
 import {
@@ -14,6 +15,8 @@ import {
   onAwarenessChangeParameters, onAwarenessUpdateParameters,
   onCloseParameters, onDisconnectParameters, onMessageParameters, onOpenParameters, onOutgoingMessageParameters, onStatusParameters,
 } from './types.js'
+
+export type HocusPocusWebSocket = WebSocket & { identifier: string };
 
 export type HocuspocusProviderWebsocketConfiguration =
   Required<Pick<CompleteHocuspocusProviderWebsocketConfiguration, 'url'>>
@@ -136,7 +139,9 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
   subscribedToBroadcastChannel = false
 
-  webSocket: WebSocket | null = null
+  webSocket: HocusPocusWebSocket | null = null
+
+  webSocketHandlers: { [key: string]: any } = {}
 
   shouldConnect = true
 
@@ -152,15 +157,17 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   }
 
   connectionAttempt: {
-    resolve: (value?: any) => void
-    reject: (reason?: any) => void
+    resolve: (value?: any) => void;
+    reject: (reason?: any) => void;
   } | null = null
 
   constructor(configuration: HocuspocusProviderWebsocketConfiguration) {
     super()
     this.setConfiguration(configuration)
 
-    this.configuration.WebSocketPolyfill = configuration.WebSocketPolyfill ? configuration.WebSocketPolyfill : WebSocket
+    this.configuration.WebSocketPolyfill = configuration.WebSocketPolyfill
+      ? configuration.WebSocketPolyfill
+      : WebSocket
 
     this.on('open', this.configuration.onOpen)
     this.on('open', this.onOpen.bind(this))
@@ -177,8 +184,6 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     this.on('close', this.onClose.bind(this))
     this.on('message', this.onMessage.bind(this))
-
-    this.registerEventListeners()
 
     this.intervals.connectionChecker = setInterval(
       this.checkConnection.bind(this),
@@ -224,10 +229,11 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
   detach(provider: HocuspocusProvider) {
     // tell the server to remove the listener
-
   }
 
-  public setConfiguration(configuration: Partial<HocuspocusProviderWebsocketConfiguration> = {}): void {
+  public setConfiguration(
+    configuration: Partial<HocuspocusProviderWebsocketConfiguration> = {},
+  ): void {
     this.configuration = { ...this.configuration, ...configuration }
   }
 
@@ -289,24 +295,59 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     return retryPromise
   }
 
+  attachWebSocketListeners(ws: HocusPocusWebSocket, reject: Function) {
+    const { identifier } = ws
+    const onMessageHandler = (payload: any) => this.emit('message', payload)
+    const onCloseHandler = (payload: any) => this.emit('close', { event: payload })
+    const onOpenHandler = (payload: any) => this.emit('open', payload)
+    const onErrorHandler = (err: any) => {
+      reject(err)
+    }
+
+    this.webSocketHandlers[identifier] = {
+      message: onMessageHandler,
+      close: onCloseHandler,
+      open: onOpenHandler,
+      error: onErrorHandler,
+    }
+
+    const handlers = this.webSocketHandlers[ws.identifier]
+
+    Object.keys(handlers).forEach(name => {
+      ws.addEventListener(name, handlers[name])
+    })
+  }
+
+  cleanupWebSocket() {
+    if (!this.webSocket) {
+      return
+    }
+    const { identifier } = this.webSocket
+    const handlers = this.webSocketHandlers[identifier]
+
+    Object.keys(handlers).forEach(name => {
+      this.webSocket?.removeEventListener(name, handlers[name])
+      delete this.webSocketHandlers[identifier]
+    })
+    this.webSocket.close()
+    this.webSocket = null
+  }
+
   createWebSocketConnection() {
     return new Promise((resolve, reject) => {
       if (this.webSocket) {
         this.messageQueue = []
-        this.webSocket.close()
-        this.webSocket = null
+        this.cleanupWebSocket()
       }
       this.lastMessageReceived = 0
 
       // Init the WebSocket connection
       const ws = new this.configuration.WebSocketPolyfill(this.url)
       ws.binaryType = 'arraybuffer'
-      ws.onmessage = (payload: any) => this.emit('message', payload)
-      ws.onclose = (payload: any) => this.emit('close', { event: payload })
-      ws.onopen = (payload: any) => this.emit('open', payload)
-      ws.onerror = (err: any) => {
-        reject(err)
-      }
+      ws.identifier = uuidv4()
+
+      this.attachWebSocketListeners(ws, reject)
+
       this.webSocket = ws
 
       // Reset the status
@@ -363,7 +404,10 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     }
 
     // Don’t close the connection when a message was received recently
-    if (this.configuration.messageReconnectTimeout >= time.getUnixTime() - this.lastMessageReceived) {
+    if (
+      this.configuration.messageReconnectTimeout
+      >= time.getUnixTime() - this.lastMessageReceived
+    ) {
       return
     }
 
@@ -384,15 +428,6 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
       this.webSocket?.close()
       this.messageQueue = []
     }
-
-  }
-
-  registerEventListeners() {
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    window.addEventListener('online', this.boundConnect)
   }
 
   // Ensure that the URL always ends with /
@@ -435,7 +470,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
   onClose({ event }: onCloseParameters) {
     this.closeTries = 0
-    this.webSocket = null
+    this.cleanupWebSocket()
 
     if (this.status === WebSocketStatus.Connected) {
       this.status = WebSocketStatus.Disconnected
@@ -445,9 +480,13 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     if (event.code === Unauthorized.code) {
       if (event.reason === Unauthorized.reason) {
-        console.warn('[HocuspocusProvider] An authentication token is required, but you didn’t send one. Try adding a `token` to your HocuspocusProvider configuration. Won’t try again.')
+        console.warn(
+          '[HocuspocusProvider] An authentication token is required, but you didn’t send one. Try adding a `token` to your HocuspocusProvider configuration. Won’t try again.',
+        )
       } else {
-        console.warn(`[HocuspocusProvider] Connection closed with status Unauthorized: ${event.reason}`)
+        console.warn(
+          `[HocuspocusProvider] Connection closed with status Unauthorized: ${event.reason}`,
+        )
       }
 
       this.shouldConnect = false
@@ -455,13 +494,17 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     if (event.code === Forbidden.code) {
       if (!this.configuration.quiet) {
-        console.warn('[HocuspocusProvider] The provided authentication token isn’t allowed to connect to this server. Will try again.')
+        console.warn(
+          '[HocuspocusProvider] The provided authentication token isn’t allowed to connect to this server. Will try again.',
+        )
         return // TODO REMOVE ME
       }
     }
 
     if (event.code === MessageTooBig.code) {
-      console.warn(`[HocuspocusProvider] Connection closed with status MessageTooBig: ${event.reason}`)
+      console.warn(
+        `[HocuspocusProvider] Connection closed with status MessageTooBig: ${event.reason}`,
+      )
       this.shouldConnect = false
     }
 
@@ -507,11 +550,6 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     this.removeAllListeners()
 
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    window.removeEventListener('online', this.boundConnect)
+    this.cleanupWebSocket()
   }
-
 }

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -7,7 +7,6 @@ import * as time from 'lib0/time'
 import * as url from 'lib0/url'
 import type { MessageEvent } from 'ws'
 import { Event } from 'ws'
-import { uuidv4 } from 'lib0/random.js'
 import EventEmitter from './EventEmitter.js'
 import { HocuspocusProvider } from './HocuspocusProvider.js'
 import {
@@ -148,6 +147,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   status = WebSocketStatus.Disconnected
 
   lastMessageReceived = 0
+
+  identifier = 0
 
   mux = mutex.createMutex()
 
@@ -340,11 +341,12 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
         this.cleanupWebSocket()
       }
       this.lastMessageReceived = 0
+      this.identifier += 1
 
       // Init the WebSocket connection
       const ws = new this.configuration.WebSocketPolyfill(this.url)
       ws.binaryType = 'arraybuffer'
-      ws.identifier = uuidv4()
+      ws.identifier = this.identifier
 
       this.attachWebSocketListeners(ws, reject)
 


### PR DESCRIPTION
Currently websocket listeners are not cleaned up on disconnection and `createWebSocketConnection` is called from multiple sources which results in multiple sockets to be created every time a user comes back online from sleep or there is a disruption in connectivity. 

Steps to reproduce:
1. Open playground (connect to a remote websocket server as it wont occur if you are connecting to 127.0.0.1)
2. Switch wifi from network a to b
3. Initial socket will timeout depending on your `messageReconnectTimeout` value (hearbeat failure).
5. New socket is created
6. Browser calls onClose after about a minute or so, (network tab shows socket duration instead of pending state once close is received). This event triggers a new connection setup.
7. Two connections are now open both have listeners attached and are sending/received data. However, hocuspocus only has reference to one. Keep repeating the process and the number of sockets will keep on increasing and connected sockets go into retry loop and a new socket is created for each close event sent by the browser.

The online event listener also calls `createWebSocketConnection` 

After this change only 1 socket is active at any given time. This PR is just a reference to fix the underlying issue. It can be fixed in multiple ways. I think the event emitter should be bound with the lifecycle of the websocket. Currently even stale websockets emit events that are handled with the latest context.

Ran lint:fix so there are some extra lint changes. 
`attachWebSocketListeners` stores the reference of attached listeners.
`cleanupWebSocket` removes the listeners before resetting reference of the websocket.
`online` event listener has been removed as it leads to a duplicate socket. Once connection has been established, sockets are retried anyway infinite times. If initial connection fails, the retry wrapper takes over and attempts only the number of times that have been set. 
Added an identifier to the socket instance.

Before:

https://github.com/ueberdosis/hocuspocus/assets/49636500/c045b6f9-ac72-4cd8-b5cb-8836d02991f4


After:
![image](https://github.com/ueberdosis/hocuspocus/assets/49636500/5b04f5d6-478d-403d-b3f1-a9d258986931)
