### PR TITLE
Stop listening to messages once the websocket closes

### DIFF
--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -88,7 +88,12 @@ export class ClientConnection {
       websocket.close(Unauthorized.code, Unauthorized.reason)
     }, opts.timeout)
 
+    console.log('on(message)', this.socketId)
     websocket.on('message', this.messageHandler)
+    websocket.once('close', () => {
+      console.log('off(message)', this.socketId)
+      websocket.removeListener('message', this.messageHandler)
+    })
   }
 
   /**

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -88,10 +88,8 @@ export class ClientConnection {
       websocket.close(Unauthorized.code, Unauthorized.reason)
     }, opts.timeout)
 
-    console.log('on(message)', this.socketId)
     websocket.on('message', this.messageHandler)
     websocket.once('close', () => {
-      console.log('off(message)', this.socketId)
       websocket.removeListener('message', this.messageHandler)
     })
   }


### PR DESCRIPTION
The ClientConnection is responsible to clean up the 'message' listener