### PR TITLE
server/examples.md: Remove outdated documentName references

### DIFF
--- a/docs/server/examples.md
+++ b/docs/server/examples.md
@@ -44,10 +44,9 @@ app.get("/", (request, response) => {
 });
 
 // Add a websocket route for Hocuspocus
-// Note: make sure to include a parameter for the document name.
 // You can set any contextual data like in the onConnect hook
 // and pass it to the handleConnection method.
-app.ws("/collaboration/:document", (websocket, request) => {
+app.ws("/collaboration", (websocket, request) => {
   const context = {
     user: {
       id: 1234,
@@ -83,12 +82,10 @@ const app = new Koa();
 app.use(websocket());
 
 // Add a websocket route for Hocuspocus
-// Note: make sure to include a parameter for the document name.
 // You can set any contextual data like in the onConnect hook
 // and pass it to the handleConnection method.
 app.use(async (ctx, next) => {
   const ws = await ctx.ws();
-  const documentName = ctx.request.path.substring(1);
 
   server.handleConnection(
     ws,


### PR DESCRIPTION
I've reviewed the `handleConnection` interface, and I don't see anywhere that `documentName` is used. Was this part of a previous version? I think this is no longer needed, but correct me if I'm wrong.

I actually tried out the express example, and it did not work with `/:documentName`, but it worked when I removed it.