### PR TITLE
Send Timeout code instead of Auth failed on initial connection timeout

### DIFF
--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -328,8 +328,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 
     Object.keys(handlers).forEach(name => {
       this.webSocket?.removeEventListener(name, handlers[name])
-      delete this.webSocketHandlers[identifier]
     })
+    delete this.webSocketHandlers[identifier]
     this.webSocket.close()
     this.webSocket = null
   }

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -1,7 +1,7 @@
 import { IncomingHttpHeaders, IncomingMessage } from 'http'
 import { URLSearchParams } from 'url'
 import {
-  Forbidden, Unauthorized, WsReadyStates,
+  Forbidden, Unauthorized, WsReadyStates, ConnectionTimeout,
 } from '@hocuspocus/common'
 import * as decoding from 'lib0/decoding'
 import { v4 as uuid } from 'uuid'
@@ -85,7 +85,7 @@ export class ClientConnection {
   ) {
     // Make sure to close an idle connection after a while.
     this.closeIdleConnectionTimeout = setTimeout(() => {
-      websocket.close(Unauthorized.code, Unauthorized.reason)
+      websocket.close(ConnectionTimeout.code, ConnectionTimeout.reason)
     }, opts.timeout)
 
     websocket.on('message', this.messageHandler)


### PR DESCRIPTION
## Description

When a socket connection times out on the server side (i.e. server does not receive token for specified duration) we send 401 code by default. 
The issue with this is that the token may be delayed for a wide variety of reasons, while sending a 401 prevents auto reconnect loop on the frontend by default, leading to either socket never getting connected from frontend, or frontend showing Unauthorized messaging to the user.
Using 408 code ensures that the frontend can keep reconnecting, and only throw 401 when we actually have an invalid token