### PR TITLE
Fix payload types for after load/unload document hooks

### DIFF
--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -42,7 +42,7 @@ export interface Extension {
   connected?(data: connectedPayload): Promise<any>;
   onAuthenticate?(data: onAuthenticatePayload): Promise<any>;
   onLoadDocument?(data: onLoadDocumentPayload): Promise<any>;
-  afterLoadDocument?(data: onLoadDocumentPayload): Promise<any>;
+  afterLoadDocument?(data: afterLoadDocumentPayload): Promise<any>;
   beforeHandleMessage?(data: beforeHandleMessagePayload): Promise<any>;
   beforeBroadcastStateless?(data: beforeBroadcastStatelessPayload): Promise<any>;
   onStateless?(payload: onStatelessPayload): Promise<any>;
@@ -52,7 +52,7 @@ export interface Extension {
   onAwarenessUpdate?(data: onAwarenessUpdatePayload): Promise<any>;
   onRequest?(data: onRequestPayload): Promise<any>;
   onDisconnect?(data: onDisconnectPayload): Promise<any>;
-  afterUnloadDocument?(data: onLoadDocumentPayload): Promise<any>;
+  afterUnloadDocument?(data: afterUnloadDocumentPayload): Promise<any>;
   onDestroy?(data: onDestroyPayload): Promise<any>;
 }
 
@@ -85,7 +85,7 @@ export type HookPayloadByName = {
   connected: connectedPayload,
   onAuthenticate: onAuthenticatePayload,
   onLoadDocument: onLoadDocumentPayload,
-  afterLoadDocument: onLoadDocumentPayload,
+  afterLoadDocument: afterLoadDocumentPayload,
   beforeHandleMessage: beforeHandleMessagePayload,
   beforeBroadcastStateless: beforeBroadcastStatelessPayload,
   onStateless: onStatelessPayload,


### PR DESCRIPTION
The types of the payloads for the `afterLoadDocument` and `afterUnloadDocument` hooks are `onLoadDocumentPayload`, which I think is just copy-pasta because there are specific types defined for their payloads.