### PR TITLE
fix: add documentName into broadcast message

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -546,11 +546,16 @@ export class HocuspocusProvider extends EventEmitter {
     }
 
     this.mux(() => {
-      this.broadcast(SyncStepOneMessage, { document: this.document })
-      this.broadcast(SyncStepTwoMessage, { document: this.document })
-      this.broadcast(QueryAwarenessMessage, { document: this.document })
+      this.broadcast(SyncStepOneMessage, { document: this.document, documentName: this.configuration.name })
+      this.broadcast(SyncStepTwoMessage, { document: this.document, documentName: this.configuration.name })
+      this.broadcast(QueryAwarenessMessage, { document: this.document, documentName: this.configuration.name })
       if (this.awareness) {
-        this.broadcast(AwarenessMessage, { awareness: this.awareness, clients: [this.document.clientID], document: this.document })
+        this.broadcast(AwarenessMessage, {
+          awareness: this.awareness,
+          clients: [this.document.clientID],
+          document: this.document,
+          documentName: this.configuration.name,
+        })
       }
     })
   }


### PR DESCRIPTION
Since I upgraded to v2.6.0, the `provider` will throw an error when creating a connection, like the following:
![screenshot](https://github.com/ueberdosis/hocuspocus/assets/46624780/836d3379-0fa0-4075-ac0d-88150d990628)

This error occurs because the `documentName` parameter is missing when broadcasting the message.
This PR complements the `documentName` parameter for broadcasting.