### PR TITLE
Fix return type of database extension `store` method

### DIFF
--- a/packages/extension-database/src/Database.ts
+++ b/packages/extension-database/src/Database.ts
@@ -16,7 +16,7 @@ export interface DatabaseConfiguration {
   /**
    * Pass a function to store updates in your database.
    */
-  store: (data: storePayload) => void,
+  store: (data: storePayload) => Promise<void>,
 }
 
 export class Database implements Extension {
@@ -25,7 +25,7 @@ export class Database implements Extension {
    */
   configuration: DatabaseConfiguration = {
     fetch: async () => null,
-    store: async () => null,
+    store: async () => {},
   }
 
   /**
@@ -55,7 +55,7 @@ export class Database implements Extension {
    * Store new updates in the database.
    */
   async onStoreDocument(data: onChangePayload) {
-    return this.configuration.store({
+    await this.configuration.store({
       ...data,
       state: Buffer.from(
         Y.encodeStateAsUpdate(data.document),


### PR DESCRIPTION
This PR changes the type of the database extension's `store` method from

```typescript
(data: storePayload) => void
```

to 

```typescript
(data: storePayload) => Promise<void>
```

to make it clear that the function is expected to be asynchronous and will be awaited in the `onStoreDocument` hook.

Also, instead of returning the promise directly from the extensions `onStoreDocument`, it is now awaited to ensure that the call stack on any error is correct.