### PR TITLE
Add `context` to `onAuthenticatePayload`

### DIFF
--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -161,6 +161,7 @@ export interface onStatelessPayload {
 // @todo Change 'connection' to 'connectionConfig' in next major release
 // see https://github.com/ueberdosis/hocuspocus/pull/607#issuecomment-1553559805
 export interface onAuthenticatePayload {
+  context: any,
   documentName: string,
   instance: Hocuspocus,
   requestHeaders: IncomingHttpHeaders,


### PR DESCRIPTION
The `onAuthenticatePayload` type doesn't include the `context` field, but this is actually present (and it is useful to be able to read the context set by `handleConnection` in `onAuthenticate`).