### PR TITLE
Handle errors thrown by provider token function

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -387,9 +387,17 @@ export class HocuspocusProvider extends EventEmitter {
 
     this.emit('open', { event })
 
+    let token: string | null
+    try {
+      token = await this.getToken()
+    } catch (error) {
+      this.permissionDeniedHandler(`Failed to get token: ${error}`)
+      return
+    }
+
     if (this.isAuthenticationRequired) {
       this.send(AuthenticationMessage, {
-        token: await this.getToken(),
+        token,
         documentName: this.configuration.name,
       })
     }


### PR DESCRIPTION
If you set `token` to be a function in the provider configuration, and that function throws an error, that's currently an unhandled promise rejection.

This PR handles the error by calling the `permissionDeniedHandler` so that the provider emits an `authenticationFailed` event that the user can handle.