### PR TITLE
Efficiently route messages through HocuspocusProviderWebsocket

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -192,8 +192,6 @@ export class HocuspocusProvider extends EventEmitter {
     this.configuration.websocketProvider.on('open', this.boundOnOpen)
     this.configuration.websocketProvider.on('open', this.forwardOpen)
 
-    this.configuration.websocketProvider.on('message', this.boundOnMessage)
-
     this.configuration.websocketProvider.on('close', this.boundOnClose)
     this.configuration.websocketProvider.on('close', this.configuration.onClose)
     this.configuration.websocketProvider.on('close', this.forwardClose)
@@ -233,8 +231,6 @@ export class HocuspocusProvider extends EventEmitter {
   boundPageUnload = this.pageUnload.bind(this)
 
   boundOnOpen = this.onOpen.bind(this)
-
-  boundOnMessage = this.onMessage.bind(this)
 
   boundOnClose = this.onClose.bind(this)
 
@@ -447,10 +443,6 @@ export class HocuspocusProvider extends EventEmitter {
 
     const documentName = message.readVarString()
 
-    if (documentName !== this.configuration.name) {
-      return // message is meant for another provider
-    }
-
     message.writeVarString(documentName)
 
     this.emit('message', { event, message: new IncomingMessage(event.data) })
@@ -494,7 +486,6 @@ export class HocuspocusProvider extends EventEmitter {
     this.configuration.websocketProvider.off('connect', this.forwardConnect)
     this.configuration.websocketProvider.off('open', this.boundOnOpen)
     this.configuration.websocketProvider.off('open', this.forwardOpen)
-    this.configuration.websocketProvider.off('message', this.boundOnMessage)
     this.configuration.websocketProvider.off('close', this.boundOnClose)
     this.configuration.websocketProvider.off('close', this.configuration.onClose)
     this.configuration.websocketProvider.off('close', this.forwardClose)

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -379,8 +379,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     this.lastMessageReceived = time.getUnixTime()
 
     const message = new IncomingMessage(event.data)
-    const documentName = message.readVarString()
-    message.writeVarString(documentName)
+    const documentName = message.peekVarString()
 
     this.configuration.providerMap.get(documentName)?.onMessage(event)
   }

--- a/packages/provider/src/IncomingMessage.ts
+++ b/packages/provider/src/IncomingMessage.ts
@@ -1,5 +1,6 @@
 import {
   createDecoder,
+  peekVarString,
   readVarUint,
   readVarUint8Array,
   readVarString,
@@ -27,6 +28,10 @@ export class IncomingMessage {
     this.data = data
     this.encoder = createEncoder()
     this.decoder = createDecoder(new Uint8Array(this.data))
+  }
+
+  peekVarString(): string {
+    return peekVarString(this.decoder)
   }
 
   readVarUint(): MessageType {


### PR DESCRIPTION
This PR changes the provider's onMessage running time from O(n) to O(1), where n is the number of all attached providers. It does this by adding a Map to the `HocuspocusProviderWebsocket` configuration that allows O(1) lookup of attached providers by document name. It will then manually call onMessage on the appropriate provider and only that provider. 

Fixes #724