### PR TITLE
fixes #730: Reverts breaking change: When the update is incoming via …

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -374,7 +374,8 @@ export class Hocuspocus {
     // If the update was received through other ways than the
     // WebSocket connection, we don’t need to feel responsible for
     // storing the content.
-    if (!connection) {
+    // also ignore changes incoming through redis connection, as this would be a breaking change (#730, #696, #606)
+    if (!connection || (connection as unknown as string) === '__hocuspocus__redis__origin__') {
       return
     }
 


### PR DESCRIPTION
…redis, we shouldnt run onStoreDocument hooks; refs #730, refs #696, refs #606