### PR TITLE
Add misssing hooks to config-hooks-extension.

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -116,6 +116,7 @@ export class Hocuspocus {
       connected: this.configuration.connected,
       onAuthenticate: this.configuration.onAuthenticate,
       onLoadDocument: this.configuration.onLoadDocument,
+      afterLoadDocument: this.configuration.afterLoadDocument,
       beforeHandleMessage: this.configuration.beforeHandleMessage,
       beforeBroadcastStateless: this.configuration.beforeBroadcastStateless,
       onStateless: this.configuration.onStateless,
@@ -124,6 +125,7 @@ export class Hocuspocus {
       afterStoreDocument: this.configuration.afterStoreDocument,
       onAwarenessUpdate: this.configuration.onAwarenessUpdate,
       onRequest: this.configuration.onRequest,
+      afterUnloadDocument: this.configuration.afterUnloadDocument,
       onDisconnect: this.configuration.onDisconnect,
       onDestroy: this.configuration.onDestroy,
     })

--- a/tests/server/openDirectConnection.ts
+++ b/tests/server/openDirectConnection.ts
@@ -173,7 +173,7 @@ test('direct connection transact awaits until onStoreDocument has finished, even
 
   await new Promise(async resolve => {
     const server = await newHocuspocus({
-      unloadImmediately: true,
+      unloadImmediately: false,
       onStoreDocument: async () => {
 
         onStoreDocumentFinished = false
@@ -185,7 +185,7 @@ test('direct connection transact awaits until onStoreDocument has finished, even
         }
       },
       afterUnloadDocument: async data => {
-        if (directConnDisconnecting) {
+        if (!storedAfterDisconnect) {
           t.fail('this shouldnt be called')
         }
       },


### PR DESCRIPTION
`afterLoadDocument` and `afterUnloadDocument` hook functions passed in `HocuspocusServer.configure({ ... })` will not be called, these two hooks have not been added to the config-hooks-extension.

https://github.com/ueberdosis/hocuspocus/blob/74c53ccef08e81017b59ef7cf9131d4344867d1b/packages/server/src/Hocuspocus.ts#L111-L129

https://github.com/ueberdosis/hocuspocus/blob/74c53ccef08e81017b59ef7cf9131d4344867d1b/packages/server/src/Hocuspocus.ts#L437-L438

https://github.com/ueberdosis/hocuspocus/blob/74c53ccef08e81017b59ef7cf9131d4344867d1b/packages/server/src/Hocuspocus.ts#L491-L499