### PR TITLE
change URL of Tiptap Cloud

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -15,7 +15,7 @@ export type TiptapCollabProviderConfiguration =
 
 export interface AdditionalTiptapCollabProviderConfiguration {
   /**
-   * A Hocuspocus Cloud App ID, get one here: https://collab.tiptap.dev
+   * A Hocuspocus Cloud App ID, get one here: https://cloud.tiptap.dev
    */
   appId?: string,
 

--- a/packages/provider/src/TiptapCollabProviderWebsocket.ts
+++ b/packages/provider/src/TiptapCollabProviderWebsocket.ts
@@ -9,7 +9,7 @@ export type TiptapCollabProviderWebsocketConfiguration =
 
 export interface AdditionalTiptapCollabProviderWebsocketConfiguration {
   /**
-   * A Hocuspocus Cloud App ID, get one here: https://collab.tiptap.dev
+   * A Hocuspocus Cloud App ID, get one here: https://cloud.tiptap.dev
    */
   appId: string,
 }


### PR DESCRIPTION
I changed the Tiptap Cloud URL from collab.tiptap.dev to cloud.tiptap.dev.