### PR TITLE
Improve Logger Extension

### DIFF
--- a/packages/server/src/Debugger.ts
+++ b/packages/server/src/Debugger.ts
@@ -26,6 +26,30 @@ export class Debugger {
     this.output = false
   }
 
+  info(...args: any) {
+    if (this.output) {
+      console.info(...args);
+    }
+  }
+
+  warn(...args: any) {
+    if (this.output) {
+      console.warn(...args);
+    }
+  }
+
+  error(...args: any) {
+    if (this.output) {
+      console.error(...args);
+    }
+  }
+
+  debug(...args: any) {
+    if (this.output) {
+      console.debug(...args);
+    }
+  }
+
   log(message: any) {
     if (!this.listen) {
       return this


### PR DESCRIPTION
Right now, the logger extension doesn't have any affect on the hocuspocus instances debugger property. I'm not sure if it was intended to work this way, but I feel that it would make much more sense for the logger to be accessible in other extensions such that we are able to control how logs are handled in pre-built extensions, i.e. redis and have a generic way of exposing a global logger to all extensions. 

I've also added some other common methods such as `debug` and `info`, which most common loggers would expose. 