### PR TITLE
fix (provider): Make connect call attach instead of connect

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -367,6 +367,8 @@ export class HocuspocusProvider extends EventEmitter {
       this.subscribeToBroadcastChannel()
     }
 
+    this.configuration.websocketProvider.shouldConnect = true
+
     return this.configuration.websocketProvider.attach(this)
   }
 

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -367,7 +367,7 @@ export class HocuspocusProvider extends EventEmitter {
       this.subscribeToBroadcastChannel()
     }
 
-    return this.configuration.websocketProvider.connect()
+    return this.configuration.websocketProvider.attach(this)
   }
 
   disconnect() {

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -217,7 +217,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   }
 
   attach(provider: HocuspocusProvider) {
-    let connectPromise: Promise<any> | undefined = undefined
+    let connectPromise: Promise<any> | undefined
     this.configuration.providerMap.set(provider.configuration.name, provider)
 
     if (this.status === WebSocketStatus.Disconnected && this.shouldConnect) {

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -217,10 +217,11 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
   }
 
   attach(provider: HocuspocusProvider) {
+    let connectPromise: Promise<any> | undefined = undefined
     this.configuration.providerMap.set(provider.configuration.name, provider)
 
     if (this.status === WebSocketStatus.Disconnected && this.shouldConnect) {
-      this.connect()
+      connectPromise = this.connect()
     }
 
     if (this.receivedOnOpenPayload) {
@@ -230,6 +231,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
     if (this.receivedOnStatusPayload) {
       provider.onStatus(this.receivedOnStatusPayload)
     }
+
+    return connectPromise
   }
 
   detach(provider: HocuspocusProvider) {


### PR DESCRIPTION
# Changes

- Updates `Provider.connect` to call `websocketProvider.attach` instead of `websocketProvider.connect` directly to ensure that the provider is attached before connecting


Fixes #782 