### PR TITLE
fix(provider): Keep existing metadata on threads or comments instead of overriding them

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -161,7 +161,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     thread.set('updatedAt', (new Date()).toISOString())
 
     if (data.data) {
-      thread.set('data', { ...thread.data, ...data.data })
+      thread.set('data', { ...(thread.get('data') || {}), ...data.data })
     }
 
     if (data.resolvedAt || data.resolvedAt === null) {
@@ -235,7 +235,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     comment.set('updatedAt', (new Date()).toISOString())
 
     if (data.data) {
-      comment.set('data', { ...comment.data, ...data.data })
+      comment.set('data', { ...(comment?.data || {}), ...data.data })
     }
 
     if (data.content) {

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -161,7 +161,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     thread.set('updatedAt', (new Date()).toISOString())
 
     if (data.data) {
-      thread.set('data', data.data)
+      thread.set('data', { ...thread.data, ...data.data })
     }
 
     if (data.resolvedAt || data.resolvedAt === null) {
@@ -235,7 +235,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     comment.set('updatedAt', (new Date()).toISOString())
 
     if (data.data) {
-      comment.set('data', data.data)
+      comment.set('data', { ...comment.data, ...data.data })
     }
 
     if (data.content) {


### PR DESCRIPTION
The new threads functions on the Tiptap collab provider allow users to update threads or comments - however this will override the whole data object even if only one key is updated.

This PR will allow users to update only single keys.
@janthurau do you think this makes sense or should we solve this another way?