### PR TITLE
fix: allow resolvedAt to be null on updateThread

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -157,7 +157,9 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     return createdThread
   }
 
-  updateThread(id: TCollabThread['id'], data: Partial<Pick<TCollabThread, 'data' | 'resolvedAt'>>) {
+  updateThread(id: TCollabThread['id'], data: Partial<Pick<TCollabThread, 'data'> & {
+    resolvedAt: TCollabThread['resolvedAt'] | null
+  }>) {
     let updatedThread: TCollabThread = {} as TCollabThread
 
     this.document.transact(() => {


### PR DESCRIPTION
This PR allows the `resolvedAt` on `updateThread` to be nullable since setting it to undefined won't remove the `resolvedAt` data.