### PR TITLE
Wait for createDocument to be loaded for subsequent createConnections

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -417,12 +417,9 @@ export class Hocuspocus {
    * Create a new document by the given request
    */
   public createDocument(documentName: string, request: Partial<Pick<IncomingMessage, 'headers' | 'url'>>, socketId: string, connection: ConnectionConfiguration, context?: any): Promise<Document> {
-    if (this.loadingDocuments.has(documentName)) {
-      const documentPromise = this.loadingDocuments.get(documentName)
-
-      if (documentPromise) {
-        return documentPromise
-      }
+    const existingLoadingDoc = this.loadingDocuments.get(documentName)
+    if (existingLoadingDoc) {
+      return existingLoadingDoc
     }
 
     const loadDocPromise = this.loadDocument(documentName, request, socketId, connection, context)

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -572,6 +572,7 @@ export class Hocuspocus {
     if (!this.documents.has(documentName)) return
 
     this.documents.delete(documentName)
+    this.loadingDocuments.delete(documentName)
     document.destroy()
     this.hooks('afterUnloadDocument', { instance: this, documentName })
   }

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -416,7 +416,7 @@ export class Hocuspocus {
   /**
    * Create a new document by the given request
    */
-  public createDocument(documentName: string, request: Partial<Pick<IncomingMessage, 'headers' | 'url'>>, socketId: string, connection: ConnectionConfiguration, context?: any): Promise<Document> {
+  public async createDocument(documentName: string, request: Partial<Pick<IncomingMessage, 'headers' | 'url'>>, socketId: string, connection: ConnectionConfiguration, context?: any): Promise<Document> {
     const existingLoadingDoc = this.loadingDocuments.get(documentName)
 
     if (existingLoadingDoc) {
@@ -432,9 +432,13 @@ export class Hocuspocus {
 
     this.loadingDocuments.set(documentName, loadDocPromise)
 
-    loadDocPromise.finally(() => {
+    try {
+      await loadDocPromise
       this.loadingDocuments.delete(documentName)
-    })
+    } catch (e) {
+      this.loadingDocuments.delete(documentName)
+      throw e
+    }
 
     return loadDocPromise
   }

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -1,6 +1,8 @@
 import test from 'ava'
 import { newHocuspocus, newHocuspocusProvider } from '../utils/index.js'
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
 test('executes the onLoadDocument callback', async t => {
   await new Promise(async resolve => {
     const server = await newHocuspocus({
@@ -130,6 +132,56 @@ test('multiple simultaneous connections do not create multiple documents', async
   })
 })
 
+test('multiple simultaneous connections wait for the document to be loaded', async t => {
+  t.plan(6)
+
+  await new Promise(async resolve => {
+    let resolveOnLoadDocument: () => void = () => {}
+
+    const server = await newHocuspocus({
+      onLoadDocument({ document }) {
+        // delay more accurately simulates a database fetch
+        return new Promise(async innerResolve => {
+          resolveOnLoadDocument = () => {
+            document.getArray('foo').insert(0, ['bar'])
+            innerResolve(document)
+          }
+        })
+      },
+    })
+
+    const provider1 = newHocuspocusProvider(server)
+    const provider2 = newHocuspocusProvider(server)
+    let provider1Synced = false
+    let provider2Synced = false
+
+    provider1.on('synced', () => {
+      provider1Synced = true
+      const value = provider1.document.getArray('foo').get(0)
+      t.is(value, 'bar')
+    })
+    provider2.on('synced', () => {
+      provider2Synced = true
+      const value = provider2.document.getArray('foo').get(0)
+      t.is(value, 'bar')
+    })
+
+    await sleep(100)
+
+    t.false(provider1Synced, 'provider1Synced')
+    t.false(provider2Synced, 'provider2Synced')
+
+    resolveOnLoadDocument()
+
+    await sleep(100)
+
+    t.true(provider1Synced, 'provider1Synced')
+    t.true(provider2Synced, 'provider2Synced')
+
+    resolve('done')
+  })
+})
+
 test('has the server instance', async t => {
   await new Promise(async resolve => {
     const server = await newHocuspocus({
@@ -164,60 +216,6 @@ test('stops when an error is thrown in onLoadDocument', async t => {
   })
 })
 
-test('disconnects all clients related to the document when an error is thrown in onLoadDocument', async t => {
-  const resolvesNeeded = 4
-
-  await new Promise(async resolve => {
-
-    const server = await newHocuspocus({
-      async onLoadDocument() {
-        return new Promise((resolve, fail) => {
-          setTimeout(() => {
-            // eslint-disable-next-line prefer-promise-reject-errors
-            fail('ERROR')
-          }, 250)
-        })
-      },
-      async onStoreDocument(data) {
-        t.fail('MUST NOT call onStoreDocument')
-      },
-    })
-
-    let resolvedNumber = 0
-    const resolver = () => {
-      resolvedNumber += 1
-
-      if (resolvedNumber >= resolvesNeeded) {
-        t.is(server.documents.size, 0)
-        t.is(server.getConnectionsCount(), 0)
-        resolve('done')
-      }
-    }
-
-    const provider1 = newHocuspocusProvider(server, {
-      onConnect() {
-        resolver()
-      },
-      onClose(event) {
-        provider1.disconnect()
-        resolver()
-      },
-    })
-
-    const provider2 = newHocuspocusProvider(server, {
-      onConnect() {
-        resolver()
-      },
-      onClose() {
-        provider2.disconnect()
-        resolver()
-      },
-    })
-
-  })
-
-})
-
 test('stops when an error is thrown in onLoadDocument, even when authenticated', async t => {
   await new Promise(async resolve => {
     const server = await newHocuspocus({
@@ -239,110 +237,5 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
         t.fail()
       },
     })
-  })
-})
-
-test('if a new connection connects while the previous connection still fetches the document, it will just work properly', async t => {
-  let callsToOnLoadDocument = 0
-  const resolvesNeeded = 11
-
-  await new Promise(async resolve => {
-
-    let resolvedNumber = 0
-    const resolver = () => {
-      resolvedNumber += 1
-
-      if (resolvedNumber >= resolvesNeeded) {
-        t.is(callsToOnLoadDocument, 1)
-        resolve('done')
-      }
-    }
-
-    const server = await newHocuspocus({
-      onLoadDocument({ document }) {
-        return new Promise(async resolve => {
-          setTimeout(() => {
-            callsToOnLoadDocument += 1
-            document.getArray('foo').insert(0, [`bar-${callsToOnLoadDocument}`])
-            resolve(document)
-          }, 5000)
-        })
-      },
-    })
-
-    let provider1MessagesReceived = 0
-    const provider = newHocuspocusProvider(server, {
-      onSynced({ state }) {
-        // if (!state) return
-        t.is(server.documents.size, 1)
-
-        const value = provider.document.getArray('foo').get(0)
-        t.is(value, 'bar-1')
-
-        setTimeout(() => {
-          provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider1Synced'])
-        }, 100)
-
-        resolver()
-      },
-      onMessage() {
-        if (!provider.isSynced) return
-        provider1MessagesReceived += 1
-
-        const value = provider.document.getArray('foo').get(0)
-
-        if (provider1MessagesReceived === 1) {
-          // do nothing, this is just the ACK for the sync
-        } else if (provider1MessagesReceived === 2) {
-          // do nothing, this is just the ACK for the received update (set "bar-updatedAfterProvider1Synced")
-        } else if (provider1MessagesReceived === 3) {
-          t.is(value, 'bar-updatedAfterProvider1Synced')
-        } else {
-          t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
-        }
-
-        resolver()
-      },
-    })
-
-    let provider2MessagesReceived = 0
-    setTimeout(() => {
-      const provider2 = newHocuspocusProvider(server, {
-        onSynced({ state }) {
-          // if (!state) return
-
-          t.is(server.documents.size, 1)
-
-          const value = provider.document.getArray('foo').get(0)
-          t.is(value, undefined) // document hasnt loaded yet because it loads for 5sec, but this runs after ~2sec
-
-          resolver()
-        },
-        onMessage(data) {
-          if (!provider2.isSynced) return
-          provider2MessagesReceived += 1
-
-          const value = provider.document.getArray('foo').get(0)
-
-          if (provider2MessagesReceived === 1) {
-            // do nothing, this is just the ACK for the sync
-            t.is(value, undefined)
-          } else if (provider2MessagesReceived === 2) {
-            // initial state is now synced
-            t.is(value, undefined)
-          } else if (provider2MessagesReceived === 3) {
-            t.is(value, 'bar-updatedAfterProvider1Synced')
-            setTimeout(() => {
-              provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])
-            }, 100)
-          } else {
-            t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
-          }
-
-          resolver()
-        },
-      })
-
-    }, 2000)
   })
 })

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -289,6 +289,8 @@ test('disconnects all clients related to the document when an error is thrown in
 })
 
 test('if a new connection connects while the previous connection still fetches the document, it will just work properly', async t => {
+  t.plan(11)
+
   let callsToOnLoadDocument = 0
   const resolvesNeeded = 10
 
@@ -359,7 +361,7 @@ test('if a new connection connects while the previous connection still fetches t
 
           t.is(server.documents.size, 1)
 
-          const value = provider.document.getArray('foo').get(0)
+          const value = provider2.document.getArray('foo').get(0)
           t.is(value, 'bar-1')
 
           resolver()
@@ -368,21 +370,23 @@ test('if a new connection connects while the previous connection still fetches t
           if (!provider2.isSynced) return
           provider2MessagesReceived += 1
 
-          const value = provider.document.getArray('foo').get(0)
+          setTimeout(() => {
+            const value = provider2.document.getArray('foo').get(0)
 
-          if (provider2MessagesReceived === 1) {
+            if (provider2MessagesReceived === 1) {
             // initial state is now synced
-            t.is(value, 'bar-1')
-          } else if (provider2MessagesReceived === 2) {
-            t.is(value, 'bar-updatedAfterProvider1Synced')
-            setTimeout(() => {
-              provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])
-            }, 100)
-          } else {
-            t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
-          }
+              t.is(value, 'bar-1')
+            } else if (provider2MessagesReceived === 2) {
+              t.is(value, 'bar-updatedAfterProvider1Synced')
+              setTimeout(() => {
+                provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])
+              }, 100)
+            } else {
+              t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
+            }
+            resolver()
+          })
 
-          resolver()
         },
       })
 

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -239,3 +239,153 @@ test('stops when an error is thrown in onLoadDocument, even when authenticated',
     })
   })
 })
+
+test('disconnects all clients related to the document when an error is thrown in onLoadDocument', async t => {
+  const resolvesNeeded = 2
+
+  await new Promise(async resolve => {
+
+    const server = await newHocuspocus({
+      async onLoadDocument() {
+        return new Promise((resolve, fail) => {
+          setTimeout(() => {
+            // eslint-disable-next-line prefer-promise-reject-errors
+            fail('ERROR')
+          }, 250)
+        })
+      },
+      async onStoreDocument(data) {
+        t.fail('MUST NOT call onStoreDocument')
+      },
+    })
+
+    let resolvedNumber = 0
+    const resolver = () => {
+      resolvedNumber += 1
+
+      if (resolvedNumber >= resolvesNeeded) {
+        t.is(server.documents.size, 0)
+        t.is(server.getConnectionsCount(), 0)
+        resolve('done')
+      }
+    }
+
+    const provider1 = newHocuspocusProvider(server, {
+      onClose(event) {
+        provider1.disconnect()
+        resolver()
+      },
+    })
+
+    const provider2 = newHocuspocusProvider(server, {
+      onClose() {
+        provider2.disconnect()
+        resolver()
+      },
+    })
+
+  })
+
+})
+
+test('if a new connection connects while the previous connection still fetches the document, it will just work properly', async t => {
+  let callsToOnLoadDocument = 0
+  const resolvesNeeded = 10
+
+  await new Promise(async resolve => {
+
+    let resolvedNumber = 0
+    const resolver = () => {
+      resolvedNumber += 1
+
+      if (resolvedNumber >= resolvesNeeded) {
+        t.is(callsToOnLoadDocument, 1)
+        resolve('done')
+      }
+    }
+
+    const server = await newHocuspocus({
+      onLoadDocument({ document }) {
+        return new Promise(async resolve => {
+          setTimeout(() => {
+            callsToOnLoadDocument += 1
+            document.getArray('foo').insert(0, [`bar-${callsToOnLoadDocument}`])
+            resolve(document)
+          }, 5000)
+        })
+      },
+    })
+
+    let provider1MessagesReceived = 0
+    const provider = newHocuspocusProvider(server, {
+      onSynced({ state }) {
+        // if (!state) return
+        t.is(server.documents.size, 1)
+
+        const value = provider.document.getArray('foo').get(0)
+        t.is(value, 'bar-1')
+
+        setTimeout(() => {
+          provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider1Synced'])
+        }, 100)
+
+        resolver()
+      },
+      onMessage() {
+        if (!provider.isSynced) return
+        provider1MessagesReceived += 1
+
+        const value = provider.document.getArray('foo').get(0)
+
+        if (provider1MessagesReceived === 1) {
+          // do nothing, this is just the ACK for the sync
+        } else if (provider1MessagesReceived === 2) {
+          // do nothing, this is just the ACK for the received update (set "bar-updatedAfterProvider1Synced")
+        } else if (provider1MessagesReceived === 3) {
+          t.is(value, 'bar-updatedAfterProvider1Synced')
+        } else {
+          t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
+        }
+
+        resolver()
+      },
+    })
+
+    let provider2MessagesReceived = 0
+    setTimeout(() => {
+      const provider2 = newHocuspocusProvider(server, {
+        onSynced({ state }) {
+          // if (!state) return
+
+          t.is(server.documents.size, 1)
+
+          const value = provider.document.getArray('foo').get(0)
+          t.is(value, 'bar-1')
+
+          resolver()
+        },
+        onMessage(data) {
+          if (!provider2.isSynced) return
+          provider2MessagesReceived += 1
+
+          const value = provider.document.getArray('foo').get(0)
+
+          if (provider2MessagesReceived === 1) {
+            // initial state is now synced
+            t.is(value, 'bar-1')
+          } else if (provider2MessagesReceived === 2) {
+            t.is(value, 'bar-updatedAfterProvider1Synced')
+            setTimeout(() => {
+              provider.document.getArray('foo').insert(0, ['bar-updatedAfterProvider2ReceivedMessageFrom1'])
+            }, 100)
+          } else {
+            t.is(value, 'bar-updatedAfterProvider2ReceivedMessageFrom1')
+          }
+
+          resolver()
+        },
+      })
+
+    }, 2000)
+  })
+})


### PR DESCRIPTION
### Changes

* in `Hocuspocus` add a mapping `loadingDocuments` of `Map<string, Promise<Document>>` to store loading documents
* `createDocument` will use `loadingDocuments` to dedupe docs, always returning a promise of the fully loaded document
* Eliminate tests where it was testing clients connecting to a doc still loading.

Fixes #821 