### PR TITLE
fix: improve global window checks to enable react native support

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -306,7 +306,7 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   registerEventListeners() {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || !('addEventListener' in window)) {
       return
     }
 
@@ -506,7 +506,7 @@ export class HocuspocusProvider extends EventEmitter {
     this.send(CloseMessage, { documentName: this.configuration.name })
     this.disconnect()
 
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || !('removeEventListener' in window)) {
       return
     }
 


### PR DESCRIPTION
## Description

This pull request was opened to address the "window.addEventListener is not a function" error when trying to run Hocuspocus provider on mobile, using Expo.

Currently:

![WhatsApp Image 2024-05-15 at 23 53 56](https://github.com/ueberdosis/hocuspocus/assets/42624869/e0f86845-745d-47ee-ac5d-1c54eb63d0c6)

After changes:

https://github.com/ueberdosis/hocuspocus/assets/42624869/b4c7eba7-f6cb-4ab2-9eb6-a69d1ce20a29

## Context

After watching Evan Bacon's talk about Expo Router v3 at React Conf, I got so inspired to test real-time collaboration using Expo.
Since I am already familiar with it, why not trying hocuspocus?

To make it happen, I just needed to use a NodeJS Crypto polyfill and fix this "window" bug.

Here is the full code of the working proof of concept:
https://github.com/qwikens/qwikens-native

