### PR TITLE
Replace deprecated `unload` event with `pagehide` event

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -231,7 +231,7 @@ export class HocuspocusProvider extends EventEmitter {
 
   boundBroadcastChannelSubscriber = this.broadcastChannelSubscriber.bind(this)
 
-  boundPageUnload = this.pageUnload.bind(this)
+  boundPageHide = this.pageHide.bind(this)
 
   boundOnOpen = this.onOpen.bind(this)
 
@@ -299,9 +299,9 @@ export class HocuspocusProvider extends EventEmitter {
     this.send(SyncStepOneMessage, { document: this.document, documentName: this.configuration.name })
   }
 
-  pageUnload() {
+  pageHide() {
     if (this.awareness) {
-      removeAwarenessStates(this.awareness, [this.document.clientID], 'window unload')
+      removeAwarenessStates(this.awareness, [this.document.clientID], 'page hide')
     }
   }
 
@@ -310,7 +310,7 @@ export class HocuspocusProvider extends EventEmitter {
       return
     }
 
-    window.addEventListener('unload', this.boundPageUnload)
+    window.addEventListener('pagehide', this.boundPageHide)
   }
 
   sendStateless(payload: string) {
@@ -510,7 +510,7 @@ export class HocuspocusProvider extends EventEmitter {
       return
     }
 
-    window.removeEventListener('unload', this.boundPageUnload)
+    window.removeEventListener('pagehide', this.boundPageHide)
   }
 
   permissionDeniedHandler(reason: string) {


### PR DESCRIPTION
Dear hocuspocus folks,

I noticed that the `HocuspocusProvider` is using the deprecated `unload` event. MDN advises to use the `pagehide` event instead, so this is what I chose to use for this PR. I searched for any open and closed issues and PRs that could be related to this and hence am aware of #658 and #657, where the previously used `beforeunload` event was found to be problematic.

I checked if the `pagehide` event also fires when starting a download as described in #657 and found that it in fact does not fire. Therefore I think this event might be a viable alternative to `unload`.

Cheers,
Julian