### PR TITLE
Allow token fn to return null

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -68,7 +68,7 @@ export interface CompleteHocuspocusProviderConfiguration {
   /**
    * A token that’s sent to the backend for authentication purposes.
    */
-  token: string | (() => string) | (() => Promise<string>) | null,
+  token: string | (() => string) | (() => Promise<string | null>) | null,
   /**
    * URL parameters that should be added.
    */


### PR DESCRIPTION
The token passed as a value can be null already, so the code that calls the function will continue to work as intended.

Allowing a null value makes it possible to still open a connection without a token while attempting to fetch the token in an async function.