### PR TITLE
Don't close socket if preserveConnection is set in HocuspocusProvider

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -511,7 +511,9 @@ export class HocuspocusProvider extends EventEmitter {
     this.configuration.websocketProvider.off('destroy', this.configuration.onDestroy)
     this.configuration.websocketProvider.off('destroy', this.forwardDestroy)
 
-    this.send(CloseMessage, { documentName: this.configuration.name })
+    if (!this.configuration.preserveConnection) {
+      this.send(CloseMessage, { documentName: this.configuration.name });
+    }
     this.disconnect()
 
     if (typeof window === 'undefined' || !('removeEventListener' in window)) {


### PR DESCRIPTION
Sending the `CloseMessage` also has the effect of closing the socket according to its description.

I noticed that before patching this in the package, the socket would be closed when I called `destroy` on the provider even if it was supposed to preserve the connection. When using multiple providers on the same socket at once, it's important that no provider getting destroyed closes the whole socket. `disconnect`ing the provider is not enough because it still has listeners on the document, socket, and elsewhere which is not acceptable.