### PR TITLE
fix(provider): correct event handler binding for document updates and awareness

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -212,8 +212,8 @@ export class HocuspocusProvider extends EventEmitter {
       this.emit('awarenessChange', { states: awarenessStatesToArray(this.awareness!.getStates()) })
     })
 
-    this.document.on('update', this.documentUpdateHandler.bind(this))
-    this.awareness?.on('update', this.awarenessUpdateHandler.bind(this))
+    this.document.on('update', this.boundDocumentUpdateHandler)
+    this.awareness?.on('update', this.boundAwarenessUpdateHandler)
     this.registerEventListeners()
 
     if (
@@ -228,6 +228,9 @@ export class HocuspocusProvider extends EventEmitter {
 
     this.configuration.websocketProvider.attach(this)
   }
+
+  boundDocumentUpdateHandler = this.documentUpdateHandler.bind(this)
+  boundAwarenessUpdateHandler = this.awarenessUpdateHandler.bind(this)
 
   boundBroadcastChannelSubscriber = this.broadcastChannelSubscriber.bind(this)
 
@@ -490,11 +493,11 @@ export class HocuspocusProvider extends EventEmitter {
 
     if (this.awareness) {
       removeAwarenessStates(this.awareness, [this.document.clientID], 'provider destroy')
-      this.awareness.off('update', this.awarenessUpdateHandler)
+      this.awareness.off('update', this.boundAwarenessUpdateHandler)
       this.awareness.destroy()
     }
 
-    this.document.off('update', this.documentUpdateHandler)
+    this.document.off('update', this.boundDocumentUpdateHandler)
 
     this.removeAllListeners()
 

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -230,6 +230,7 @@ export class HocuspocusProvider extends EventEmitter {
   }
 
   boundDocumentUpdateHandler = this.documentUpdateHandler.bind(this)
+
   boundAwarenessUpdateHandler = this.awarenessUpdateHandler.bind(this)
 
   boundBroadcastChannelSubscriber = this.broadcastChannelSubscriber.bind(this)


### PR DESCRIPTION
Fixed an issue where event handlers for document and awareness updates leaks on destroy.