### PR TITLE
feature(provider): implement comment tombstones for threads

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -17,7 +17,12 @@ export type TiptapCollabProviderConfiguration =
   (Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'websocketProvider'>> |
   Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'appId'>>|
   Required<Pick<AdditionalTiptapCollabProviderConfiguration, 'baseUrl'>>) &
-  Pick<AdditionalTiptapCollabProviderConfiguration, 'user'>
+  Pick<AdditionalTiptapCollabProviderConfiguration, 'user'> & {
+    /**
+     * Pass `true` if you want to delete a thread when the first comment is deleted.
+     */
+    deleteThreadOnFirstCommentDelete?: boolean,
+  }
 
 export interface AdditionalTiptapCollabProviderConfiguration {
   /**
@@ -308,7 +313,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     // if the first comment of a thread is deleted we also
     // delete the thread itself as the source comment is gone
-    if (commentIndex === 0 && deleteThread) {
+    if (commentIndex === 0 && (deleteThread || (this.configuration as TiptapCollabProviderConfiguration).deleteThreadOnFirstCommentDelete)) {
       this.deleteThread(threadId)
       return
     }

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -125,7 +125,17 @@ export class TiptapCollabProvider extends HocuspocusProvider {
    * @returns An array of threads as JSON objects
    */
   getThreads<Data, CommentData>(): TCollabThread<Data, CommentData>[] {
-    return this.getYThreads().toJSON() as TCollabThread<Data, CommentData>[]
+    let threads = this.getYThreads().toJSON() as TCollabThread<Data, CommentData>[]
+
+    threads = threads.map(thread => ({
+      ...thread,
+      deletedComments: thread.deletedComments.map(c => ({
+        ...c,
+        content: null,
+      })),
+    }))
+
+    return threads
   }
 
   /**
@@ -263,7 +273,16 @@ export class TiptapCollabProvider extends HocuspocusProvider {
       return null
     }
 
-    return (!deleted ? this.getThread(threadId)?.comments : this.getThread(threadId)?.deletedComments) ?? []
+    let comments = !deleted ? this.getThread(threadId)?.comments : this.getThread(threadId)?.deletedComments
+
+    if (deleted) {
+      comments = comments?.map(c => ({
+        ...c,
+        content: null,
+      }))
+    }
+
+    return comments ?? []
   }
 
   /**

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -315,7 +315,15 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     if (commentIndex > 0) {
       const comment = thread.get('comments').get(commentIndex)
-      thread.get('deletedComments').push([comment])
+      const newComment = new Y.Map()
+
+      newComment.set('id', comment.get('id'))
+      newComment.set('createdAt', comment.get('createdAt'))
+      newComment.set('updatedAt', (new Date()).toISOString())
+      newComment.set('data', comment.get('data'))
+      newComment.set('content', null)
+
+      thread.get('deletedComments').push([newComment])
       thread.get('comments').delete(commentIndex)
     }
 

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -406,6 +406,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
       newComment.set('id', comment.get('id'))
       newComment.set('createdAt', comment.get('createdAt'))
       newComment.set('updatedAt', (new Date()).toISOString())
+      newComment.set('deletedAt', (new Date()).toISOString())
       newComment.set('data', comment.get('data'))
       newComment.set('content', null)
 

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -278,7 +278,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
       return null
     }
 
-    return [...this.getThreadComments(threadId) ?? [], ...this.getThreadComments(threadId, true) ?? []].sort((a, b) => a.createdAt - b.createdAt)
+    return [...this.getThreadComments(threadId) ?? [], ...this.getThreadComments(threadId, true) ?? []].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
   }
 
   /**

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -399,20 +399,18 @@ export class TiptapCollabProvider extends HocuspocusProvider {
       return
     }
 
-    if (commentIndex > 0) {
-      const comment = thread.get('comments').get(commentIndex)
-      const newComment = new Y.Map()
+    const comment = thread.get('comments').get(commentIndex)
+    const newComment = new Y.Map()
 
-      newComment.set('id', comment.get('id'))
-      newComment.set('createdAt', comment.get('createdAt'))
-      newComment.set('updatedAt', (new Date()).toISOString())
-      newComment.set('deletedAt', (new Date()).toISOString())
-      newComment.set('data', comment.get('data'))
-      newComment.set('content', null)
+    newComment.set('id', comment.get('id'))
+    newComment.set('createdAt', comment.get('createdAt'))
+    newComment.set('updatedAt', (new Date()).toISOString())
+    newComment.set('deletedAt', (new Date()).toISOString())
+    newComment.set('data', comment.get('data'))
+    newComment.set('content', comment.get('content'))
 
-      thread.get('deletedComments').push([newComment])
-      thread.get('comments').delete(commentIndex)
-    }
+    thread.get('deletedComments').push([newComment])
+    thread.get('comments').delete(commentIndex)
 
     return thread.toJSON() as TCollabThread
   }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -120,6 +120,7 @@ export type TCollabComment<Data = any> = {
   id: string;
   createdAt: string;
   updatedAt: string;
+  deletedAt?: string;
   data: Data
   content: any
 }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -118,8 +118,8 @@ export type TCollabThread<Data = any, CommentData = any> = {
 
 export type TCollabComment<Data = any> = {
   id: string;
-  createdAt: number;
-  updatedAt: number;
+  createdAt: string;
+  updatedAt: string;
   data: Data
   content: any
 }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -112,6 +112,7 @@ export type TCollabThread<Data = any, CommentData = any> = {
   updatedAt: number;
   resolvedAt?: string; // (new Date()).toISOString()
   comments: TCollabComment<CommentData>[];
+  deletedComments: TCollabComment<CommentData>[];
   data: Data
 }
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -185,3 +185,15 @@ export type THistoryDocumentRevertedEvent = {
   event: 'document.reverted';
   version: number;
 };
+
+export type DeleteCommentOptions = {
+  /**
+   * If `true`, the thread will also be deleted if the deleted comment was the first comment in the thread.
+   */
+  deleteThread?: boolean
+
+  /**
+   * If `true`, will remove the content of the deleted comment
+   */
+  deleteContent?: boolean
+}


### PR DESCRIPTION
This pull request includes changes to the `TiptapCollabProvider` class to support handling deleted comments separated from non-deleted comments in threads. The most important changes include adding a new `deletedComments` field to the `TCollabThread` type, modifying methods to manage and retrieve deleted comments, and updating the logic for deleting comments.
llaborative editing sessions.

Enhancements to thread and comment management:

* [`TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR121-R141): Added methods to get, create, update, and delete threads and comments, including support for deleted comments. Added JSDoc comments for better documentation. [[1]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR121-R141) [[2]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR158-R162) [[3]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR173-R177) [[4]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL154-R201) [[5]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR210-R215) [[6]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR244-R248) [[7]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL208-R304) [[8]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR326-R333) [[9]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL284-R378) [[10]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL300-R426)

New configuration options:

* [`TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR11-R31): Introduced `deleteThreadOnFirstCommentDelete` option to automatically delete a thread when its first comment is deleted. Added `defaultDeleteCommentOptions` for handling comment deletion.

Updates to data types:

* [`types.ts`](diffhunk://#diff-9672b197f8befe1ede0bdc9d6458f6f076be4029d5951ba8bae18d8565365f8fR115-R123): Updated `TCollabThread` and `TCollabComment` types to include `deletedComments` and `deletedAt` fields, respectively. Added `DeleteCommentOptions` type for comment deletion options. [[1]](diffhunk://#diff-9672b197f8befe1ede0bdc9d6458f6f076be4029d5951ba8bae18d8565365f8fR115-R123) [[2]](diffhunk://#diff-9672b197f8befe1ede0bdc9d6458f6f076be4029d5951ba8bae18d8565365f8fR188-R199)