### PR TITLE
fix(server): pass `WebSocket` instead of Connection to `applyAwarenessUpdate`

### DIFF
--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -65,7 +65,7 @@ export class MessageReceiver {
           category: 'Update',
         })
 
-        applyAwarenessUpdate(document.awareness, message.readVarUint8Array(), connection)
+        applyAwarenessUpdate(document.awareness, message.readVarUint8Array(), connection?.webSocket)
 
         break
       }


### PR DESCRIPTION
This fix resolves an issue where [`applyAwarenessUpdate`](https://github.com/ueberdosis/hocuspocus/blob/main/packages/server/src/MessageReceiver.ts#L68) was incorrectly called with a `Connection` object instead of the expected `WebSocket` in the [`handleAwarenessUpdate`](https://github.com/ueberdosis/hocuspocus/blob/main/packages/server/src/Document.ts#L192) method.