### PR TITLE
fix(comments): fix error where deletedComments yArray does not exist

### DIFF
--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -406,7 +406,9 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     newComment.set('data', comment.get('data'))
     newComment.set('content', deleteContent ? null : comment.get('content'))
 
-    thread.get('deletedComments').push([newComment])
+    const deletedComments = thread.get('deletedComments') || new Y.Array()
+    deletedComments.push([newComment])
+
     thread.get('comments').delete(commentIndex)
 
     return thread.toJSON() as TCollabThread

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -408,10 +408,8 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     if (!thread.get('deletedComments')) {
       thread.set('deletedComments', new Y.Array())
-      thread.get('deletedComments').push([newComment])
-    } else {
-      thread.get('deletedComments').push([newComment])
     }
+    thread.get('deletedComments').push([newComment])
 
     thread.get('comments').delete(commentIndex)
 

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -406,8 +406,12 @@ export class TiptapCollabProvider extends HocuspocusProvider {
     newComment.set('data', comment.get('data'))
     newComment.set('content', deleteContent ? null : comment.get('content'))
 
-    const deletedComments = thread.get('deletedComments') || new Y.Array()
-    deletedComments.push([newComment])
+    if (!thread.get('deletedComments')) {
+      thread.set('deletedComments', new Y.Array())
+      thread.get('deletedComments').push([newComment])
+    } else {
+      thread.get('deletedComments').push([newComment])
+    }
 
     thread.get('comments').delete(commentIndex)
 


### PR DESCRIPTION
This pull request includes a change to the `TiptapCollabProvider` class in the `packages/provider/src/TiptapCollabProvider.ts` file. The change ensures that the `deletedComments` array is properly initialized before pushing a new comment.

* [`packages/provider/src/TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL409-R411): Modified the `TiptapCollabProvider` class to initialize `deletedComments` with a new `Y.Array()` if it is not already defined.