### PR TITLE
feature(provider): allow thread tombstoning and restoration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20119,7 +20119,7 @@
         "kleur": "^4.1.4",
         "lodash.debounce": "^4.0.8",
         "redlock": "^4.2.0",
-        "uuid": "^10.0.0"
+        "uuid": "^11.0.3"
       },
       "devDependencies": {
         "@types/ioredis": "^4.28.7",
@@ -20132,15 +20132,16 @@
       }
     },
     "packages/extension-redis/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/extension-sqlite": {
@@ -20222,7 +20223,7 @@
         "async-lock": "^1.3.1",
         "kleur": "^4.1.4",
         "lib0": "^0.2.47",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.3",
         "ws": "^8.5.0"
       },
       "devDependencies": {
@@ -20236,15 +20237,16 @@
       }
     },
     "packages/server/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/server/node_modules/ws": {
@@ -21797,13 +21799,13 @@
         "kleur": "^4.1.4",
         "lodash.debounce": "^4.0.8",
         "redlock": "^4.2.0",
-        "uuid": "^10.0.0"
+        "uuid": "^11.0.3"
       },
       "dependencies": {
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+          "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg=="
         }
       }
     },
@@ -21947,14 +21949,14 @@
         "async-lock": "^1.3.1",
         "kleur": "^4.1.4",
         "lib0": "^0.2.47",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.3",
         "ws": "^8.5.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+          "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg=="
         },
         "ws": {
           "version": "8.5.0",

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -8,7 +8,6 @@ import {
 
 import { TiptapCollabProviderWebsocket } from './TiptapCollabProviderWebsocket.js'
 import {
-  ThreadType,
   type DeleteCommentOptions,
   type DeleteThreadOptions,
   type GetThreadsOptions,
@@ -21,7 +20,7 @@ const defaultDeleteCommentOptions: DeleteCommentOptions = {
 }
 
 const defaultGetThreadsOptions: GetThreadsOptions = {
-  types: [ThreadType.Unarchived],
+  types: ['unarchived'],
 }
 
 const defaultDeleteThreadOptions: DeleteThreadOptions = {
@@ -148,16 +147,16 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     const threads = this.getYThreads().toJSON() as TCollabThread<Data, CommentData>[]
 
-    if (types?.includes(ThreadType.Archived) && types?.includes(ThreadType.Unarchived)) {
+    if (types?.includes('archived') && types?.includes('unarchived')) {
       return threads
     }
 
     return threads.filter(currentThead => {
-      if (types?.includes(ThreadType.Archived) && currentThead.deletedAt) {
+      if (types?.includes('archived') && currentThead.deletedAt) {
         return true
       }
 
-      if (types?.includes(ThreadType.Unarchived) && !currentThead.deletedAt) {
+      if (types?.includes('unarchived') && !currentThead.deletedAt) {
         return true
       }
 
@@ -175,7 +174,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     let i = 0
     // eslint-disable-next-line no-restricted-syntax
-    for (const thread of this.getThreads({ types: [ThreadType.Archived, ThreadType.Unarchived] })) {
+    for (const thread of this.getThreads({ types: ['archived', 'unarchived'] })) {
       if (thread.id === id) {
         index = i
         break

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -7,11 +7,12 @@ import {
 } from './HocuspocusProvider.js'
 
 import { TiptapCollabProviderWebsocket } from './TiptapCollabProviderWebsocket.js'
-import type {
-  DeleteCommentOptions,
-  DeleteThreadOptions,
-  GetThreadsOptions,
-  TCollabComment, TCollabThread, THistoryVersion,
+import {
+  ThreadType,
+  type DeleteCommentOptions,
+  type DeleteThreadOptions,
+  type GetThreadsOptions,
+  type TCollabComment, type TCollabThread, type THistoryVersion,
 } from './types.js'
 
 const defaultDeleteCommentOptions: DeleteCommentOptions = {
@@ -20,7 +21,7 @@ const defaultDeleteCommentOptions: DeleteCommentOptions = {
 }
 
 const defaultGetThreadsOptions: GetThreadsOptions = {
-  types: ['undeleted'],
+  types: [ThreadType.Unarchived],
 }
 
 const defaultDeleteThreadOptions: DeleteThreadOptions = {
@@ -147,16 +148,16 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     const threads = this.getYThreads().toJSON() as TCollabThread<Data, CommentData>[]
 
-    if (types?.includes('deleted') && types?.includes('undeleted')) {
+    if (types?.includes(ThreadType.Archived) && types?.includes(ThreadType.Unarchived)) {
       return threads
     }
 
     return threads.filter(currentThead => {
-      if (types?.includes('deleted') && currentThead.deletedAt) {
+      if (types?.includes(ThreadType.Archived) && currentThead.deletedAt) {
         return true
       }
 
-      if (types?.includes('undeleted') && !currentThead.deletedAt) {
+      if (types?.includes(ThreadType.Unarchived) && !currentThead.deletedAt) {
         return true
       }
 
@@ -174,7 +175,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     let i = 0
     // eslint-disable-next-line no-restricted-syntax
-    for (const thread of this.getThreads({ types: ['deleted', 'undeleted'] })) {
+    for (const thread of this.getThreads({ types: [ThreadType.Archived, ThreadType.Unarchived] })) {
       if (thread.id === id) {
         index = i
         break

--- a/packages/provider/src/TiptapCollabProvider.ts
+++ b/packages/provider/src/TiptapCollabProvider.ts
@@ -20,7 +20,7 @@ const defaultDeleteCommentOptions: DeleteCommentOptions = {
 }
 
 const defaultGetThreadsOptions: GetThreadsOptions = {
-  types: ['deleted', 'undeleted'],
+  types: ['undeleted'],
 }
 
 const defaultDeleteThreadOptions: DeleteThreadOptions = {
@@ -174,7 +174,7 @@ export class TiptapCollabProvider extends HocuspocusProvider {
 
     let i = 0
     // eslint-disable-next-line no-restricted-syntax
-    for (const thread of this.getThreads()) {
+    for (const thread of this.getThreads({ types: ['deleted', 'undeleted'] })) {
       if (thread.id === id) {
         index = i
         break

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -216,3 +216,11 @@ export type DeleteThreadOptions = {
    */
   force?: boolean,
 }
+
+export type GetThreadsOptions = {
+  /**
+   * The types of threads to get
+   * @default `['deleted', 'undeleted']`
+   */
+  types?: Array<'deleted' | 'undeleted'>
+}

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -110,6 +110,7 @@ export type TCollabThread<Data = any, CommentData = any> = {
   id: string;
   createdAt: number;
   updatedAt: number;
+  deletedAt: number | null;
   resolvedAt?: string; // (new Date()).toISOString()
   comments: TCollabComment<CommentData>[];
   deletedComments: TCollabComment<CommentData>[];
@@ -196,4 +197,22 @@ export type DeleteCommentOptions = {
    * If `true`, will remove the content of the deleted comment
    */
   deleteContent?: boolean
+}
+
+export type DeleteThreadOptions = {
+  /**
+   * If `true`, will remove the comments on the thread,
+   * otherwise will only mark the thread as deleted
+   * and keep the comments
+   * @default false
+   */
+  deleteComments?: boolean
+
+  /**
+   * If `true`, will forcefully remove the thread and all comments,
+   * otherwise will only mark the thread as deleted
+   * and keep the comments
+   * @default false
+   */
+  force?: boolean,
 }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -217,10 +217,22 @@ export type DeleteThreadOptions = {
   force?: boolean,
 }
 
+export enum ThreadType {
+  /**
+   * A archived thread
+   */
+  Archived = 'archived',
+
+  /**
+   * A unarchived thread
+   */
+  Unarchived = 'unarchived',
+}
+
 export type GetThreadsOptions = {
   /**
    * The types of threads to get
-   * @default ['undeleted']
+   * @default ['unarchived']
    */
-  types?: Array<'deleted' | 'undeleted'>
+  types?: Array<ThreadType>
 }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -220,7 +220,7 @@ export type DeleteThreadOptions = {
 export type GetThreadsOptions = {
   /**
    * The types of threads to get
-   * @default `['deleted', 'undeleted']`
+   * @default ['undeleted']
    */
   types?: Array<'deleted' | 'undeleted'>
 }

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -217,17 +217,10 @@ export type DeleteThreadOptions = {
   force?: boolean,
 }
 
-export enum ThreadType {
-  /**
-   * A archived thread
-   */
-  Archived = 'archived',
-
-  /**
-   * A unarchived thread
-   */
-  Unarchived = 'unarchived',
-}
+/**
+ * The type of thread
+ */
+export type ThreadType = 'archived' | 'unarchived'
 
 export type GetThreadsOptions = {
   /**


### PR DESCRIPTION
This pull request to `packages/provider` introduces several enhancements and new features related to thread management in the `TiptapCollabProvider` class. The changes include the addition of new options for handling threads, improvements to thread deletion and restoration, and updates to the type definitions.

Enhancements to thread management:

* [`packages/provider/src/TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR12-R13): Added new options `DeleteThreadOptions` and `GetThreadsOptions` to control the output and deletion of threads. The `getThreads` method now accepts an `options` parameter to filter threads based on their deletion status. [[1]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR12-R13) [[2]](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcR142-R164)
* [`packages/provider/src/TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL245-R326): Introduced the `restoreThread` method to restore deleted threads by setting the `deletedAt` property to `null`.
* [`packages/provider/src/TiptapCollabProvider.ts`](diffhunk://#diff-811a6faec592b48056e4a70d311dd8596878f455baf0978454be672cbb8718fcL245-R326): Updated the `deleteThread` method to support soft deletion (marking as deleted) and forceful deletion of threads and their comments based on the provided options.

Type definition updates:

* [`packages/provider/src/types.ts`](diffhunk://#diff-9672b197f8befe1ede0bdc9d6458f6f076be4029d5951ba8bae18d8565365f8fR113): Added `deletedAt` property to the `TCollabThread` type to indicate the deletion status of a thread.
* [`packages/provider/src/types.ts`](diffhunk://#diff-9672b197f8befe1ede0bdc9d6458f6f076be4029d5951ba8bae18d8565365f8fR201-R226): Defined new types `DeleteThreadOptions` and `GetThreadsOptions` to support the new options in thread management methods.