### PR TITLE
Doc: add missing await in "Editing a document locally" example.

### DIFF
--- a/docs/server/examples.md
+++ b/docs/server/examples.md
@@ -222,5 +222,5 @@ await docConnection.transact((doc) => {
   doc.getMap('test').set('a', 'b');
 });
 
-docConnection.disconnect()
+await docConnection.disconnect()
 ```


### PR DESCRIPTION
DirectConnection.disconnect() is an async function and should be await to wait for its promise to complete.

Notes: experienced C++/Java dev, but total Typescript beginner, so make sure to check.