### PR TITLE
adjust server global active connection counter to consider multiplexing

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -274,10 +274,17 @@ export class Hocuspocus {
    * Get the total number of active connections
    */
   getConnectionsCount(): number {
-    return Array.from(this.documents.values()).reduce((acc, document) => {
-      acc += document.getConnectionsCount()
-      return acc
+    const uniqueSocketIds = new Set<string>()
+    const totalDirectConnections = Array.from(this.documents.values()).reduce((acc, document) => {
+      // Accumulate unique socket IDs
+      document.getConnections().forEach(({ socketId }) => {
+        uniqueSocketIds.add(socketId)
+      })
+      // Accumulate direct connections
+      return acc + document.directConnectionsCount
     }, 0)
+    // Return the sum of unique socket IDs and direct connections
+    return uniqueSocketIds.size + totalDirectConnections
   }
 
   /**

--- a/tests/server/onAuthenticate.ts
+++ b/tests/server/onAuthenticate.ts
@@ -362,7 +362,7 @@ test('onAuthenticate readonly auth only affects 1 doc (when multiplexing)', asyn
     tt.is(providerOK.status, WebSocketStatus.Connected)
     tt.is(providerReadOnly.status, WebSocketStatus.Connected)
     tt.is(server.getDocumentsCount(), 2)
-    tt.is(server.getConnectionsCount(), 2)
+    tt.is(server.getConnectionsCount(), 1)
     tt.is(socket.status, WebSocketStatus.Connected)
   })
 

--- a/tests/server/onClose.ts
+++ b/tests/server/onClose.ts
@@ -42,7 +42,7 @@ test('server closes connection only after receiving close event from all connect
     })
 
     await retryableAssertion(t, t2 => {
-      t2.is(server.getConnectionsCount(), 2)
+      t2.is(server.getConnectionsCount(), 1)
     })
 
     socket.shouldConnect = false

--- a/tests/utils/newHocuspocusProvider.ts
+++ b/tests/utils/newHocuspocusProvider.ts
@@ -1,6 +1,6 @@
 import {
   HocuspocusProvider,
-  HocuspocusProviderConfiguration, HocuspocusProviderWebsocketConfiguration,
+  HocuspocusProviderConfiguration, HocuspocusProviderWebsocket, HocuspocusProviderWebsocketConfiguration,
 } from '@hocuspocus/provider'
 import { Hocuspocus } from '@hocuspocus/server'
 import { newHocuspocusProviderWebsocket } from './newHocuspocusProviderWebsocket.js'
@@ -9,9 +9,10 @@ export const newHocuspocusProvider = (
   server: Hocuspocus,
   options: Partial<HocuspocusProviderConfiguration> = {},
   websocketOptions: Partial<HocuspocusProviderWebsocketConfiguration> = {},
+  websocketProvider?: HocuspocusProviderWebsocket,
 ): HocuspocusProvider => {
   return new HocuspocusProvider({
-    websocketProvider: newHocuspocusProviderWebsocket(server, websocketOptions),
+    websocketProvider: websocketProvider ?? newHocuspocusProviderWebsocket(server, websocketOptions),
     // Just use a generic document name for all tests.
     name: 'hocuspocus-test',
     // There is no need to share data with other browser tabs in the testing environment.


### PR DESCRIPTION
This PR updates the server `getConnectionCount()` to accurately handle multiplexed connections by considering unique socketIds. The previous implementation could overcount connections when multiple documents shared the same WebSocket connection.