### PR TITLE
Fix links in extension list

### DIFF
--- a/docs/server/extensions.md
+++ b/docs/server/extensions.md
@@ -6,14 +6,14 @@ You can see [our guide to custom extensions](/guides/custom-extensions) to find 
 
 We already created some very useful extensions you should check out for sure:
 
-| Extension                               | Description                                                                    |
-|-----------------------------------------| ------------------------------------------------------------------------------ |
-| [Database](/server/extensions#database) | A generic database driver that is easily adjustable to work with any database. |
-| [Logger](/server/extensions#logger)     | Add logging to Hocuspocus.                                                     |
-| [Redis](/server/extensions#redis)       | Scale Hocuspocus horizontally with Redis.                                      |
-| [SQLite](/server/extensions#sq-lite)    | Persist documents to SQLite.        |
-| [Throttle](/server/extensions#throttle) | Throttle connections by ips.                                                   |
-| [Webhook](/server/extensions#webhook)   | Send document changes via webhook to your API.                                 |
+| Extension             | Description                                                                    |
+|-----------------------| ------------------------------------------------------------------------------ |
+| [Database](#database) | A generic database driver that is easily adjustable to work with any database. |
+| [Logger](#logger)     | Add logging to Hocuspocus.                                                     |
+| [Redis](#redis)       | Scale Hocuspocus horizontally with Redis.                                      |
+| [SQLite](#sq-lite)    | Persist documents to SQLite.                                                   |
+| [Throttle](#throttle) | Throttle connections by ips.                                                   |
+| [Webhook](#webhook)   | Send document changes via webhook to your API.                                 |
 
 ## Database
 


### PR DESCRIPTION
On the [Extensions](https://tiptap.dev/docs/hocuspocus/server/extensions) page, links in the table of contents point to a wrong location. It then redirects back to the page, but we can avoid this request by removing the path altogether and just leaving the fragment part.