### PR TITLE
fix: prevent 'afterUnloadDocument' being triggered immediately after onLoadDocument

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -530,14 +530,14 @@ export class Hocuspocus {
       () => {
         return this.hooks('onStoreDocument', hookPayload)
           .then(() => {
-            this.hooks('afterStoreDocument', hookPayload).then(() => {
+            this.hooks('afterStoreDocument', hookPayload).then(async () => {
               // Remove document from memory.
 
               if (document.getConnectionsCount() > 0) {
                 return
               }
 
-              this.unloadDocument(document)
+              await this.unloadDocument(document)
             })
           })
           .catch(error => {
@@ -589,13 +589,13 @@ export class Hocuspocus {
     return chain
   }
 
-  unloadDocument(document: Document) {
+  async unloadDocument(document: Document): Promise<any> {
     const documentName = document.name
     if (!this.documents.has(documentName)) return
 
     this.documents.delete(documentName)
     document.destroy()
-    this.hooks('afterUnloadDocument', { instance: this, documentName })
+    await this.hooks('afterUnloadDocument', { instance: this, documentName })
   }
 
   enableDebugging() {


### PR DESCRIPTION
- Leading up to the call of the `unloadDocument` method of the `Hocuspocus` class, if the document no longer has any clients, the following events are guaranteed to occur in a synchronous nature: `onStoreDocument` hooks -> `afterStoreDocument` hooks -> `unloadDocument`
- Since the `unloadDocument` method includes an asynchronous call to trigger all `afterUnloadDocument` hooks without any await, or without extending the promise chain, the completion of the `afterUnloadDocument` hook is not guaranteed when the `storeDocumentHooks` returns a resolved promise.
- This, in turn, frees the event loop and allows the Hocuspocus server to handle different hooks whilst the logic in the `afterUnloadDocument` callback is incomplete. 
- 
A particular case can arise, prompted by an instant disconnect and reconnect of the websocket, where the `afterUnloadDocument` hook is triggered immediately after the `onLoadDocument` hook for a specific document, leading to possible unexpecting behavior. 

In our example, we were using the 'afterUnloadDocument' to remove a document from a local cache. You can imagine the problems this has created when that document is removed from the cache despite being active. 