### PR TITLE
fix(server): fast ws disconnect during new conn setup

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -120,6 +120,7 @@ export class Connection {
       || this.webSocket.readyState === WsReadyStates.Closed
     ) {
       this.close()
+      return
     }
 
     try {


### PR DESCRIPTION
**Issue**

the WS could be disconnect{ing/ed} during `setUpNewConnection()` which could lead to improper state.

- `connected` hooks will be fired
  -  the followup `disconnected` event will never be fired... _WS graceful close already triggered..._
- onClose callbacks defined outside/after `createConnection()` wont be triggered
  - uncleaned status
- emitting to a closed socket 

**PR includes**

`server/src/ClientConnection.ts`
- WS state check right before WS emit events and trigger of `connected` hooks
- await `connected` hooks

`packages/server/src/Connection.ts`
- fast return if WS is closed

