### PR TITLE
Fix custom HTTP response onRequest

### DIFF
--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -105,8 +105,10 @@ export class Server {
       await this.hocuspocus.hooks('onRequest', { request, response, instance: this.hocuspocus })
 
       // default response if all prior hooks don't interfere
-      response.writeHead(200, { 'Content-Type': 'text/plain' })
-      response.end('OK')
+      if (!response.writableEnded) {
+        response.writeHead(200, { 'Content-Type': 'text/plain' })
+        response.end('OK')
+      }
     } catch (error) {
       // if a hook rejects and the error is empty, do nothing
       // this is only meant to prevent later hooks and the


### PR DESCRIPTION
**Issue**
currently, trying [such example](https://tiptap.dev/docs/hocuspocus/server/hooks#on-request) stated in the docs will ends up hard crashing the server with `Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client`.

**PR includes**
- adjusting the `requestHandler` to check if the response was already ended before setting the default, based on `response.writableEnded`.