### PR TITLE
refactor: some minor cleanup after v3

### DIFF
--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -1,11 +1,11 @@
-import type { IncomingHttpHeaders, IncomingMessage } from 'http'
-import type { URLSearchParams } from 'url'
 import {
   type CloseEvent,
   ConnectionTimeout,
   Forbidden, ResetConnection, Unauthorized, WsReadyStates,
 } from '@hocuspocus/common'
+import type { IncomingHttpHeaders, IncomingMessage } from 'http'
 import * as decoding from 'lib0/decoding'
+import type { URLSearchParams } from 'url'
 import { v4 as uuid } from 'uuid'
 import type WebSocket from 'ws'
 import Connection from './Connection.js'
@@ -16,7 +16,8 @@ import { OutgoingMessage } from './OutgoingMessage.js'
 import type {
   ConnectionConfiguration,
   beforeHandleMessagePayload,
-  onDisconnectPayload} from './types.js'
+  onDisconnectPayload
+} from './types.js'
 import {
   MessageType,
 } from './types.js'

--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -1,13 +1,13 @@
-import type { IncomingMessage as HTTPIncomingMessage } from 'http'
-import type WebSocket from 'ws'
 import {
   type CloseEvent, ResetConnection,
+  WsReadyStates,
 } from '@hocuspocus/common'
-import { WsReadyStates} from '@hocuspocus/common'
+import type { IncomingMessage as HTTPIncomingMessage } from 'http'
+import type WebSocket from 'ws'
 import type Document from './Document.js'
 import { IncomingMessage } from './IncomingMessage.js'
-import { OutgoingMessage } from './OutgoingMessage.js'
 import { MessageReceiver } from './MessageReceiver.js'
+import { OutgoingMessage } from './OutgoingMessage.js'
 import type { onStatelessPayload } from './types.js'
 
 export class Connection {
@@ -20,10 +20,10 @@ export class Connection {
 
   request: HTTPIncomingMessage
 
-  callbacks: any = {
-    onClose: [(document: Document, event?: CloseEvent) => null],
-    beforeHandleMessage: (connection: Connection, update: Uint8Array) => Promise,
-    statelessCallback: () => Promise,
+  callbacks = {
+    onClose: [(document: Document, event?: CloseEvent) => {}],
+    beforeHandleMessage: (connection: Connection, update: Uint8Array) => Promise.resolve(),
+    statelessCallback: (payload: onStatelessPayload) => Promise.resolve(),
   }
 
   socketId: string

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -1,19 +1,19 @@
-import type { IncomingMessage } from 'http'
-import { fileURLToPath } from 'node:url'
-import fs from 'node:fs'
-import { dirname, join } from 'node:path'
 import {
   ResetConnection, awarenessStatesToArray,
 } from '@hocuspocus/common'
+import type { IncomingMessage } from 'http'
+import fs from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { v4 as uuid } from 'uuid'
 import type WebSocket from 'ws'
-import type { Doc} from 'yjs'
+import type { Doc } from 'yjs'
 import { applyUpdate, encodeStateAsUpdate } from 'yjs'
-import type { Server } from './Server.js'
 import { ClientConnection } from './ClientConnection.js'
 import type Connection from './Connection.js'
 import { DirectConnection } from './DirectConnection.js'
 import Document from './Document.js'
+import type { Server } from './Server.js'
 import type {
   AwarenessUpdate,
   Configuration,
@@ -25,8 +25,8 @@ import type {
   onDisconnectPayload,
   onStoreDocumentPayload,
 } from './types.js'
-import { getParameters } from './util/getParameters.js'
 import { useDebounce } from './util/debounce.js'
+import { getParameters } from './util/getParameters.js'
 
 const meta = JSON.parse(fs.readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../package.json'), 'utf-8'))
 

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -2,9 +2,6 @@ import {
   ResetConnection, awarenessStatesToArray,
 } from '@hocuspocus/common'
 import type { IncomingMessage } from 'http'
-import fs from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { v4 as uuid } from 'uuid'
 import type WebSocket from 'ws'
 import type { Doc } from 'yjs'
@@ -27,8 +24,7 @@ import type {
 } from './types.js'
 import { useDebounce } from './util/debounce.js'
 import { getParameters } from './util/getParameters.js'
-
-const meta = JSON.parse(fs.readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../package.json'), 'utf-8'))
+import meta from '../package.json' assert { type: 'json' }
 
 export const defaultConfiguration = {
   name: null,

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -3,17 +3,13 @@ import {
   createServer,
 } from 'http'
 import type { ListenOptions } from 'net'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
-import fs from 'node:fs'
 import type WebSocket from 'ws'
 import { WebSocketServer  } from 'ws'
 import type { AddressInfo, ServerOptions } from 'ws'
 import kleur from 'kleur'
 import { defaultConfiguration, Hocuspocus } from './Hocuspocus.js'
 import type { Configuration, onListenPayload } from './types'
-
-const meta = JSON.parse(fs.readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../package.json'), 'utf-8'))
+import meta from '../package.json' assert { type: 'json' }
 
 export interface ServerConfiguration extends Configuration {
   port?: number,


### PR DESCRIPTION
This does a minor refactor to cleanup some things that got added with V3. Namely the package.json runtime import that depended on Node APIs, which could be done at build time instead
