### PR TITLE
add extension to Server types import to support ESM

### DIFF
--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -9,7 +9,7 @@ import type { AddressInfo, ServerOptions } from 'ws'
 import kleur from 'kleur'
 import meta from '../package.json' assert { type: 'json' }
 import { defaultConfiguration, Hocuspocus } from './Hocuspocus.ts'
-import type { Configuration, onListenPayload } from './types'
+import type { Configuration, onListenPayload } from './types.ts'
 
 export interface ServerConfiguration extends Configuration {
   port?: number,


### PR DESCRIPTION
This was previously an import from `./types.js` [prior to v3.0.0](https://github.com/ueberdosis/hocuspocus/blob/d4a4079e2ca1fa0b0b3ec6aa71a6ca089f02d8e0/packages/server/src/Server.ts#L11). I think maybe it got reverted [in a rebase](https://github.com/ueberdosis/hocuspocus/blob/191f201ca023c754de06765d9f3be44774543a28/packages/server/src/Server.ts#L14)? Either way, this fixes TypeScript types on the `Server` class when module resolution is set to `node16` or higher.