### PR TITLE
fix(extension-redis): unsubscribe from pubsub

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -393,7 +393,7 @@ export class Redis implements Extension {
 			this.pendingDisconnects.delete(documentName);
 
 			// Do nothing, when other users are still connected to the document.
-			if (!document || document.getConnectionsCount() > 0) {
+			if (document && document.getConnectionsCount() > 0) {
 				return;
 			}
 
@@ -404,7 +404,9 @@ export class Redis implements Extension {
 				}
 			});
 
-			this.instance.unloadDocument(document);
+			if(document) {
+				this.instance.unloadDocument(document);
+			}
 		};
 		// Delay the disconnect procedure to allow last minute syncs to happen
 		const timeout = setTimeout(disconnect, this.configuration.disconnectDelay);


### PR DESCRIPTION
Fixes an issue where Redis PubSub is not unsubscribed due to delayed disconnect logic.

The Redis subscription unsubscribe code is behind a `setTimeout` which checks if the `document` instance is still available on the parent `instance`, which for us is never since the document is disposed by the time the `setTimeout` code is called.

Additionally, the existing `unloadDocument` call is suspect, but I left it in with a check for a valid `document` instance.