### PR TITLE
update CollaborationCaret to CollaborationCursor

### DIFF
--- a/docs/guides/collaborative-editing.md
+++ b/docs/guides/collaborative-editing.md
@@ -141,13 +141,13 @@ Yes, that’s all.
 Keep in mind that WebRTC needs a signaling server to connect clients. This signaling server doesn’t receive the synced data, but helps to let clients find each other. You can [run your own signaling server](https://github.com/yjs/y-webrtc#signaling), if you like. Otherwise it’s using a default URL baked into the package.
 
 ### Show other carets
-To enable users to see the caret and text selections of each other, add the [`CollaborationCaret`](https://tiptap.dev/docs/editor/api/extensions/collaboration-caret) extension.
+To enable users to see the caret and text selections of each other, add the [`CollaborationCursor`](https://tiptap.dev/docs/editor/api/extensions/collaboration-cursor) extension.
 
 ```js
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
-import CollaborationCaret from '@tiptap/extension-collaboration-caret'
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
 import { HocuspocusProvider } from '@hocuspocus/provider'
 
 // Set up the Hocuspocus WebSocket provider
@@ -166,7 +166,7 @@ const editor = new Editor({
       document: provider.document,
     }),
     // Register the collaboration cursor extension
-    CollaborationCaret.configure({
+    CollaborationCursor.configure({
       provider: provider,
       user: {
         name: 'Cyndi Lauper',


### PR DESCRIPTION
This pull request updates the collaborative editing guide to replace references to the outdated `CollaborationCaret` extension with the newer `CollaborationCursor` extension. This change ensures the documentation aligns with the current API.

### Documentation updates:

* Replaced all mentions of `CollaborationCaret` with `CollaborationCursor` in the collaborative editing guide, including the import statement and extension configuration example.