### PR TITLE
fix: add catch on message receiver when handling message

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -188,7 +188,13 @@ export class Connection {
 		this.callbacks
 			.beforeHandleMessage(this, data)
 			.then(() => {
-				new MessageReceiver(message).apply(this.document, this);
+				new MessageReceiver(message).apply(this.document, this).catch((e: any) => {
+					console.error("closing connection because of exception", e);
+					this.close({
+						code: "code" in e ? e.code : ResetConnection.code,
+						reason: "reason" in e ? e.reason : ResetConnection.reason,
+					});
+				})
 			})
 			.catch((e: any) => {
 				console.error("closing connection because of exception", e);


### PR DESCRIPTION
Adds a catch on MessageReceiver at handleMessage on Connection.

The motivation for this is because I want to throw an Error on `beforeSync` if by someReason the sync is not wanted, and I believe that the expected behavior should be the same as if it were an error from `beforeHandleMessage`. Currently if I throw an an error happens inside `beforeSync` it becames an unhandledException.

I believe that the lack of error handling inside that then was not intentional, but if it is please let me know, so I can find another way to not apply unwanted syncs.