### PR TITLE
fix: correct database link in redis.md

### DIFF
--- a/docs/server/extensions/redis.md
+++ b/docs/server/extensions/redis.md
@@ -4,7 +4,7 @@ Hocuspocus can be scaled horizontally using the Redis extension. You can spawn m
 load balancer and sync changes and awareness states through Redis. Hocuspocus will propagate all received updates to all other instances
 using Redis and thus forward updates to all clients of all Hocuspocus instances.
 
-The Redis extension does not persist data; it only syncs data between instances. Use the [Database](/server/extensions/database) extension to store your documents.
+The Redis extension does not persist data; it only syncs data between instances. Use the [Database](/server/extensions#Database) extension to store your documents.
 
 Please note that all messages will be handled on all instances of Hocuspocus, so if you are trying to reduce cpu load by spawning multiple
 servers, you should not connect them via Redis.


### PR DESCRIPTION
The original link to the database extension resulted in a Page Not Found error.
The updated link was copied from another part of the documentation where it is already used correctly to reference the same section.