### PR TITLE
fix: use named imports for compatibility

### DIFF
--- a/packages/transformer/src/Tiptap.ts
+++ b/packages/transformer/src/Tiptap.ts
@@ -2,7 +2,7 @@ import type { Doc } from "yjs";
 // @ts-ignore
 import type { Extensions } from "@tiptap/core";
 import { getSchema } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import type { Transformer } from "./types.ts";
 import { ProsemirrorTransformer } from "./Prosemirror.ts";
 


### PR DESCRIPTION
This has been a bug in tiptap for awhile: https://github.com/ueberdosis/tiptap/issues/1580

With the current way it's written, the object that it imports is `{default: <StarterKit>, StarterKit: <StarterKit>}`.

tbh not sure why, it worked in v2. with v3 i had to update my tsconfig to `"module": "esnext"`. Perhaps it's how the StarterKit is exported? I noticed [extension-starterkit imports/exports `.js` instead of `.ts`](https://github.com/ueberdosis/tiptap/blob/develop/packages/starter-kit/src/index.ts), so I assume there's some magic going on with your build patterns, but I didn't investigate more.