### PR TITLE
docs: change "history" to "undoRedo" in line with new StarterKit 

### DIFF
--- a/docs/guides/collaborative-editing.md
+++ b/docs/guides/collaborative-editing.md
@@ -41,7 +41,7 @@ const editor = new Editor({
   extensions: [
     StarterKit.configure({
       // The Collaboration extension comes with its own history handling
-      history: false,
+      undoRedo: false,
     }),
     // Register the document with Tiptap
     Collaboration.configure({
@@ -87,7 +87,7 @@ const editor = new Editor({
   extensions: [
     StarterKit.configure({
       // The Collaboration extension comes with its own history handling
-      history: false,
+      undoRedo: false,
     }),
     // Register the document with Tiptap
     Collaboration.configure({
@@ -159,8 +159,8 @@ const provider = new HocuspocusProvider({
 const editor = new Editor({
   extensions: [
     StarterKit.configure({
-      // The Collaboration extension comes with its own history handling
-      history: false,
+      // The Collaboration extension comes with its own undoRedo handling
+      undoRedo: false,
     }),
     Collaboration.configure({
       document: provider.document,

--- a/docs/provider/examples.md
+++ b/docs/provider/examples.md
@@ -44,7 +44,7 @@ new Editor({
   element: document.querySelector(".element"),
   extensions: [
     StarterKit.configure({
-      history: false,
+      undoRedo: false,
     }),
     Collaboration.configure({
       document: ydoc,


### PR DESCRIPTION
New versions of the TipTap StarterKit renamed the "history" config option to "undoRedo".
This change was previously not taken care of in the documentation.