### PR TITLE
fix(extension-redis): avoid hard crashes of expected errors when acquiring a lock

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -136,7 +136,7 @@ export class Redis implements Extension {
 		this.sub.on("messageBuffer", this.handleIncomingMessage);
 
 		this.redlock = new Redlock([this.pub], {
-			driftFactor: 0.1
+			retryCount: 0,
 		});
 
 		const identifierBuffer = Buffer.from(

--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -241,12 +241,23 @@ export class Redis implements Extension {
     // to avoid conflict with other instances storing the same document.
     const resource = this.lockKey(documentName)
     const ttl = this.configuration.lockTimeout
-    const lock = await this.redlock.acquire([resource], ttl)
-    const oldLock = this.locks.get(resource)
-    if (oldLock) {
-      await oldLock.release
-    }
-    this.locks.set(resource, {lock})
+	try {
+    	await this.redlock.acquire([resource], ttl)
+    	const oldLock = this.locks.get(resource)
+      if (oldLock) {
+        await oldLock.release;
+      }
+	}  catch (error) {
+      //based on: https://github.com/sesamecare/redlock/blob/508e00dcd1e4d2bc6373ce455f4fe847e98a9aab/src/index.ts#L347-L349
+      if(error == 'ExecutionError: The operation was unable to achieve a quorum during its retry window.') {
+        // Expected behavior: Could not acquire lock, another instance locked it already.
+        // No further `onStoreDocument` hooks will be executed; should throw a silent error with no message.
+        throw new Error('', { cause: 'Could not acquire lock, another instance locked it already.' });
+      }
+      //unexpected error
+      console.error("unexpected error:", error);
+      throw error
+		}
   }
 
 	/**
@@ -255,17 +266,16 @@ export class Redis implements Extension {
   async afterStoreDocument({documentName, socketId}: afterStoreDocumentPayload) {
     const lockKey = this.lockKey(documentName)
     const lock = this.locks.get(lockKey)
-    if (!lock) {
-      throw new Error(`Lock created in onStoreDocument not found in afterStoreDocument: ${lockKey}`)
-    }
-    try {
-      // Always try to unlock and clean up the lock
-      lock.release = lock.lock.release()
-      await lock.release
-    } catch {
-      // Lock will expire on its own after timeout
-    } finally {
-      this.locks.delete(lockKey)
+    if (lock) {
+      try {
+        // Always try to unlock and clean up the lock
+        lock.release = lock.lock.release()
+        await lock.release
+      } catch {
+        // Lock will expire on its own after timeout
+      } finally {
+        this.locks.delete(lockKey)
+      }
     }
 		// if the change was initiated by a directConnection, we need to delay this hook to make sure sync can finish first.
 		// for provider connections, this usually happens in the onDisconnect hook


### PR DESCRIPTION
**Description**

Currently when running Hocuspocus server at scale with Redis-extension enabled _(many HP servers connecting to 1 Redis server)_; it could lead to a concurrency issues trying to acquire the lock during `onStoreDocument`. on failure, it **hard crashes the server**, with:

```log
[onStoreDocument] The operation was unable to achieve a quorum during its retry window.
Error: Unhandled Rejection at promise Promise {
  <rejected> ExecutionError: The operation was unable to achieve a quorum during its retry window.
      at Redlock._execute (/usr/src/app/node_modules/.pnpm/@sesamecare-oss+redlock@1.4.0_ioredis@5.6.1/node_modules/@sesamecare-oss/redlock/build/index.js:231:15)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
    attempts: [
     ....
    ]
  }
}
```

This seems to be a regression as part of https://github.com/ueberdosis/hocuspocus/pull/958  when switching to `@sesamecare-oss+redlock` and related refactor.

**Reproduction Scenario** 

to imitate the lock issue; You can config your server with 
```
const server = new Server({
    ...
    debounce: 1,
    maxDebounce: 2,
    extensions: [
      new Redis({
        ...,
        lockTimeout: 10000000000000000000,
      }),
      ...
  ]
});
```
then try to generate couple of saves()...

**This PR includes** 
- silent handler for expected errors when trying to acquire a lock.