### PR TITLE
feat: add onTokenSync hook for periodic token validation

### DIFF
--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -10,6 +10,7 @@ import { MessageReceiver } from "./MessageReceiver.ts";
 import { MessageSender } from "./MessageSender.ts";
 import { AuthenticationMessage } from "./OutgoingMessages/AuthenticationMessage.ts";
 import { AwarenessMessage } from "./OutgoingMessages/AwarenessMessage.ts";
+import { TokenSyncMessage } from "./OutgoingMessages/TokenSyncMessage.ts";
 import { StatelessMessage } from "./OutgoingMessages/StatelessMessage.ts";
 import { SyncStepOneMessage } from "./OutgoingMessages/SyncStepOneMessage.ts";
 import { UpdateMessage } from "./OutgoingMessages/UpdateMessage.ts";
@@ -302,6 +303,19 @@ export class HocuspocusProvider extends EventEmitter {
 			documentName: this.configuration.name,
 			payload,
 		});
+	}
+
+	async sendToken() {
+		try {
+			const token = await this.getToken();
+
+			this.send(TokenSyncMessage, {
+				token: token ?? "",
+				documentName: this.configuration.name,
+			});
+		} catch (error) {
+			console.error("Failed to getToken() during sendToken():", error);
+		}
 	}
 
 	documentUpdateHandler(update: Uint8Array, origin: any) {

--- a/packages/provider/src/MessageReceiver.ts
+++ b/packages/provider/src/MessageReceiver.ts
@@ -38,6 +38,10 @@ export class MessageReceiver {
 				this.applyQueryAwarenessMessage(provider);
 				break;
 
+			case MessageType.TokenSync:
+				this.applyTokenSyncMessage(provider);
+				break;
+
 			case MessageType.Stateless:
 				provider.receiveStateless(readVarString(message.decoder));
 				break;
@@ -134,5 +138,10 @@ export class MessageReceiver {
 				Array.from(provider.awareness.getStates().keys()),
 			),
 		);
+	}
+
+	private applyTokenSyncMessage(provider: HocuspocusProvider) {
+		// Server is requesting the current token, send it back
+		provider.sendToken();
 	}
 }

--- a/packages/provider/src/OutgoingMessages/TokenSyncMessage.ts
+++ b/packages/provider/src/OutgoingMessages/TokenSyncMessage.ts
@@ -1,0 +1,27 @@
+import { writeVarString, writeVarUint } from "lib0/encoding";
+import type { OutgoingMessageArguments } from "../types.ts";
+import { MessageType } from "../types.ts";
+import { OutgoingMessage } from "../OutgoingMessage.ts";
+
+export class TokenSyncMessage extends OutgoingMessage {
+	type = MessageType.TokenSync;
+
+	description = "Token Sync";
+
+	get(args: Partial<OutgoingMessageArguments>) {
+		if (typeof args.token === "undefined") {
+			throw new Error("The token sync message requires `token` as an argument.");
+		}
+
+		if (!args.documentName) {
+			throw new Error("documentName is required for token sync message");
+		}
+
+		writeVarString(this.encoder, args.documentName);
+		writeVarUint(this.encoder, this.type);
+    writeVarString(this.encoder, args.token);
+
+		return this.encoder;
+	}
+}
+

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -8,6 +8,7 @@ import type { OutgoingMessage } from "./OutgoingMessage.ts";
 import type { AuthenticationMessage } from "./OutgoingMessages/AuthenticationMessage.ts";
 import type { AwarenessMessage } from "./OutgoingMessages/AwarenessMessage.ts";
 import type { QueryAwarenessMessage } from "./OutgoingMessages/QueryAwarenessMessage.ts";
+import type { TokenSyncMessage } from "./OutgoingMessages/TokenSyncMessage.ts";
 import type { SyncStepOneMessage } from "./OutgoingMessages/SyncStepOneMessage.ts";
 import type { SyncStepTwoMessage } from "./OutgoingMessages/SyncStepTwoMessage.ts";
 import type { UpdateMessage } from "./OutgoingMessages/UpdateMessage.ts";
@@ -20,6 +21,7 @@ export enum MessageType {
 	Stateless = 5,
 	CLOSE = 7,
 	SyncStatus = 8,
+	TokenSync = 9,
 }
 
 export enum WebSocketStatus {
@@ -53,6 +55,7 @@ export type ConstructableOutgoingMessage =
 	| Constructable<AuthenticationMessage>
 	| Constructable<AwarenessMessage>
 	| Constructable<QueryAwarenessMessage>
+	| Constructable<TokenSyncMessage>
 	| Constructable<SyncStepOneMessage>
 	| Constructable<SyncStepTwoMessage>
 	| Constructable<UpdateMessage>;

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -106,6 +106,7 @@ export class Hocuspocus {
 			onConnect: this.configuration.onConnect,
 			connected: this.configuration.connected,
 			onAuthenticate: this.configuration.onAuthenticate,
+			onTokenSync: this.configuration.onTokenSync,
 			onLoadDocument: this.configuration.onLoadDocument,
 			afterLoadDocument: this.configuration.afterLoadDocument,
 			beforeHandleMessage: this.configuration.beforeHandleMessage,

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -77,6 +77,12 @@ export class MessageReceiver {
 
 				break;
 			}
+			case MessageType.TokenSync: {
+        connection?.callbacks.onTokenSyncCallback({
+					token: message.readVarString(),
+				});
+				break;
+			}
 			case MessageType.Stateless: {
 				connection?.callbacks.statelessCallback({
 					connection,

--- a/packages/server/src/OutgoingMessage.ts
+++ b/packages/server/src/OutgoingMessage.ts
@@ -70,6 +70,15 @@ export class OutgoingMessage {
 		return this;
 	}
 
+	writeTokenSync(): OutgoingMessage {
+		this.type = MessageType.TokenSync;
+		this.category = "TokenSync";
+
+		writeVarUint(this.encoder, MessageType.TokenSync);
+
+		return this;
+	}
+
 	writeAuthenticated(readonly: boolean): OutgoingMessage {
 		this.type = MessageType.Auth;
 		this.category = "Authenticated";

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -20,6 +20,7 @@ export enum MessageType {
 	BroadcastStateless = 6,
 	CLOSE = 7,
 	SyncStatus = 8,
+	TokenSync = 9,
 }
 
 export interface AwarenessUpdate {
@@ -42,6 +43,7 @@ export interface Extension {
 	onConnect?(data: onConnectPayload): Promise<any>;
 	connected?(data: connectedPayload): Promise<any>;
 	onAuthenticate?(data: onAuthenticatePayload): Promise<any>;
+	onTokenSync?(data: onTokenSyncPayload): Promise<any>;
 	onCreateDocument?(data: onCreateDocumentPayload): Promise<any>;
 	onLoadDocument?(data: onLoadDocumentPayload): Promise<any>;
 	afterLoadDocument?(data: afterLoadDocumentPayload): Promise<any>;
@@ -69,6 +71,7 @@ export type HookName =
 	| "onConnect"
 	| "connected"
 	| "onAuthenticate"
+	| "onTokenSync"
 	| "onCreateDocument"
 	| "onLoadDocument"
 	| "afterLoadDocument"
@@ -93,6 +96,7 @@ export type HookPayloadByName = {
 	onConnect: onConnectPayload;
 	connected: connectedPayload;
 	onAuthenticate: onAuthenticatePayload;
+	onTokenSync: onTokenSyncPayload;
 	onCreateDocument: onCreateDocumentPayload;
 	onLoadDocument: onLoadDocumentPayload;
 	afterLoadDocument: afterLoadDocumentPayload;
@@ -172,6 +176,19 @@ export interface onAuthenticatePayload {
 	socketId: string;
 	token: string;
 	connectionConfig: ConnectionConfiguration;
+}
+
+export interface onTokenSyncPayload {
+	context: any;
+  document: Document;
+	documentName: string;
+	instance: Hocuspocus;
+	requestHeaders: IncomingHttpHeaders;
+	requestParameters: URLSearchParams;
+	socketId: string;
+	token: string;
+	connectionConfig: ConnectionConfiguration;
+  connection: Connection;
 }
 
 export interface onCreateDocumentPayload {

--- a/tests/server/onTokenSync.ts
+++ b/tests/server/onTokenSync.ts
@@ -1,0 +1,374 @@
+import test from 'ava'
+import type { onAuthenticatePayload, onTokenSyncPayload } from '@hocuspocus/server'
+import { WebSocketStatus } from '@hocuspocus/provider'
+import {
+  newHocuspocus, newHocuspocusProvider, newHocuspocusProviderWebsocket, sleep,
+} from '../utils/index.ts'
+import { retryableAssertion } from '../utils/retryableAssertion.ts'
+
+// ============================================================================
+// PROVIDER SEND TOKEN TESTS
+// Provider calls sendToken() after onAuthenticated()
+// ============================================================================
+
+test('provider sendToken: onTokenSync receives correct token from provider after authentication', async t => {
+  await new Promise(async resolve => {
+    const expectedToken = 'UPDATED-TOKEN'
+
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true // Allow initial auth
+      },
+      async onTokenSync({ token }: onTokenSyncPayload) {
+        t.is(token, expectedToken)
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'INITIAL-TOKEN', // Initial token for auth
+      onAuthenticated() {
+        // Provider sends updated token after authentication
+        provider.sendToken() // This will send the current token
+      },
+    })
+
+    // Update the provider's token before sending
+    provider.configuration.token = expectedToken
+
+    await sleep(100)
+  })
+})
+
+test('provider sendToken: executes onTokenSync from custom extension when provider sends token', async t => {
+  await new Promise(async resolve => {
+    class CustomExtension {
+      async onAuthenticate() {
+        return true
+      }
+
+      async onTokenSync({ token }: onTokenSyncPayload) {
+        t.is(token, 'SUPER-SECRET-TOKEN')
+        t.pass()
+        resolve('done')
+      }
+    }
+
+    const server = await newHocuspocus({
+      extensions: [
+        new CustomExtension(),
+      ],
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'SUPER-SECRET-TOKEN',
+      onAuthenticated() {
+        provider.sendToken()
+      },
+    })
+
+    await sleep(100)
+  })
+})
+
+
+
+test('provider sendToken: onTokenSync has access to full payload when provider sends token', async t => {
+  const mockContext = { user: 123 }
+
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return mockContext
+      },
+      async onTokenSync({ context, connection, documentName, token }: onTokenSyncPayload) {
+        t.deepEqual(context, mockContext)
+        t.truthy(connection)
+        t.is(documentName, 'hocuspocus-test')
+        t.is(token, 'SUPER-SECRET-TOKEN')
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'SUPER-SECRET-TOKEN',
+      onAuthenticated() {
+        provider.sendToken()
+      },
+    })
+
+    await sleep(100)
+  })
+})
+
+test('provider sendToken: onTokenSync works with multiple providers sending tokens', async t => {
+  const doc1 = 'document1'
+  const doc2 = 'document2'
+  const token1 = 'TOKEN-1'
+  const token2 = 'TOKEN-2'
+  let completedCount = 0
+
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true // Allow initial auth
+      },
+      async onTokenSync({ documentName, token }: onTokenSyncPayload) {
+        // Direct verification based on document name
+        if (documentName === doc1) {
+          t.is(token, token1)
+        } else if (documentName === doc2) {
+          t.is(token, token2)
+        }
+
+        completedCount++
+        if (completedCount === 2) {
+          resolve('done')
+        }
+      },
+    })
+
+    const socket = newHocuspocusProviderWebsocket(server)
+
+    // Create two providers for different documents
+    const provider1 = newHocuspocusProvider(server, {
+      websocketProvider: socket,
+      token: token1,
+      name: doc1,
+      onAuthenticated() {
+        provider1.sendToken()
+      },
+    })
+
+    const provider2 = newHocuspocusProvider(server, {
+      websocketProvider: socket,
+      token: token2,
+      name: doc2,
+      onAuthenticated() {
+        provider2.sendToken()
+      },
+    })
+
+    await sleep(100)
+  })
+})
+
+// ============================================================================
+// SERVER REQUEST TOKEN TESTS
+// Server calls connection.requestToken() after onAuthenticate() completes
+// ============================================================================
+
+test('server requestToken: executes onTokenSync when server requests token after authentication', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true
+      },
+      async onTokenSync({ token }: onTokenSyncPayload) {
+        t.is(token, 'SUPER-SECRET-TOKEN')
+        t.pass()
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'SUPER-SECRET-TOKEN',
+    })
+
+    await sleep(100)
+
+    const document = server.documents.get('hocuspocus-test')
+    if (document) {
+      const connection = document.connections.values().next().value?.connection
+      if (connection) {
+        connection.requestToken()
+      }
+    }
+  })
+})
+
+test('server requestToken: executes onTokenSync from custom extension when server requests token', async t => {
+  await new Promise(async resolve => {
+    class CustomExtension {
+      async onAuthenticate() {
+        return true
+      }
+
+      async onTokenSync({ token }: onTokenSyncPayload) {
+        t.is(token, 'SUPER-SECRET-TOKEN')
+        t.pass()
+        resolve('done')
+      }
+    }
+
+    const server = await newHocuspocus({
+      extensions: [
+        new CustomExtension(),
+      ],
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'SUPER-SECRET-TOKEN',
+    })
+
+    await sleep(100)
+
+    const document = server.documents.get('hocuspocus-test')
+    if (document) {
+      const connection = document.connections.values().next().value?.connection
+      if (connection) {
+        connection.requestToken()
+      }
+    }
+  })
+})
+
+test('server requestToken: onTokenSync receives correct token when server requests it', async t => {
+  await new Promise(async resolve => {
+    const expectedToken = 'UPDATED-TOKEN'
+
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true
+      },
+      async onTokenSync({ token }: onTokenSyncPayload) {
+        t.is(token, expectedToken)
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'INITIAL-TOKEN',
+    })
+
+    // Update the provider's token after connection
+    provider.configuration.token = expectedToken
+
+    await sleep(100)
+
+    // Now trigger token sync request from server
+    const document = server.documents.get('hocuspocus-test')
+    if (document) {
+      const connection = document.connections.values().next().value?.connection
+      if (connection) {
+        connection.requestToken()
+      }
+    }
+  })
+})
+
+test('server requestToken: onTokenSync works with multiple documents when server requests tokens', async t => {
+  const doc1 = 'document1'
+  const doc2 = 'document2'
+  const token1 = 'TOKEN-1'
+  const token2 = 'TOKEN-2'
+  let completedCount = 0
+
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true // Allow initial auth
+      },
+      async onTokenSync({ documentName, token }: onTokenSyncPayload) {
+        // Direct verification based on document name
+        if (documentName === doc1) {
+          t.is(token, token1)
+        } else if (documentName === doc2) {
+          t.is(token, token2)
+        }
+
+        completedCount++
+        if (completedCount === 2) {
+          resolve('done')
+        }
+      },
+    })
+
+    const socket = newHocuspocusProviderWebsocket(server)
+
+    // Create two providers for different documents
+    const provider1 = newHocuspocusProvider(server, {
+      websocketProvider: socket,
+      token: token1,
+      name: doc1,
+    })
+
+    const provider2 = newHocuspocusProvider(server, {
+      websocketProvider: socket,
+      token: token2,
+      name: doc2,
+    })
+
+    // Wait for both authentications to complete
+    await sleep(100)
+
+    // Now trigger token sync requests from server for both documents
+    const doc1Connection = server.documents.get(doc1)?.connections.values().next().value?.connection
+    const doc2Connection = server.documents.get(doc2)?.connections.values().next().value?.connection
+
+    if (doc1Connection) doc1Connection.requestToken()
+    if (doc2Connection) doc2Connection.requestToken()
+  })
+})
+
+test('server requestToken: onTokenSync works with readonly connections when server requests token', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate({ connectionConfig }: onAuthenticatePayload) {
+        connectionConfig.readOnly = true
+        return true
+      },
+      async onTokenSync({ connection }: onTokenSyncPayload) {
+        t.is(connection.readOnly, true)
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'readonly-token',
+    })
+
+    // Wait for authentication to complete first
+    await sleep(100)
+
+    // Now trigger token sync request from server
+    const document = server.documents.get('hocuspocus-test')
+    if (document) {
+      const connection = document.connections.values().next().value?.connection
+      if (connection) {
+        connection.requestToken()
+      }
+    }
+  })
+})
+
+test('server requestToken: failure of onTokenSync should trigger onAuthenticationFailed hook on provider side', async t => {
+  await new Promise(async resolve => {
+    const server = await newHocuspocus({
+      async onAuthenticate() {
+        return true // Allow initial auth
+      },
+      async onTokenSync() {
+        throw new Error('Token sync failed')
+      },
+    })
+
+    const provider = newHocuspocusProvider(server, {
+      token: 'SUPER-SECRET-TOKEN',
+      onAuthenticationFailed() {
+        t.pass()
+        resolve('done')
+      },
+    })
+
+    await sleep(100)
+
+    const document = server.documents.get('hocuspocus-test')
+    if (document) {
+      const connection = document.connections.values().next().value?.connection
+      if (connection) {
+        connection.requestToken()
+      }
+    }
+  })
+})

--- a/tests/utils/redisConnectionSettings.ts
+++ b/tests/utils/redisConnectionSettings.ts
@@ -1,4 +1,4 @@
 export const redisConnectionSettings = {
   host: process.env.REDIS_HOST || '127.0.0.1',
-  port: parseInt(process.env.REDIS_PORT || '', 10) || 6379,
+  port: Number.parseInt(process.env.REDIS_PORT || '', 10) || 6379,
 }


### PR DESCRIPTION
## Problem
Currently, Hocuspocus only validates user authentication during the initial handshake. If a user's access is revoked while they have an active connection, they can continue editing documents until they reconnect.

## Solution
This PR suggests the first step towards "periodic" reauth (ref: https://github.com/ueberdosis/hocuspocus/issues/752) by adding a token synchronization mechanism. The server can now request the current token from any connected provider, enabling validation of user permissions without requiring a full reconnection.

## Changes
- **`sendToken()`** - Provider method to send current token to server
- **`requestToken()`** - Server method to request token from provider  
- **`onTokenSync` hook** - Server hook triggered when token is received
- **`TokenSync` message type** - New message type for token synchronization

## Looking for Feedback
- any concerns about the flow or hook naming?
- should we add additional error handling for token validation failures?
  - should `onTokenSync` hook failures trigger disconnection?
  - what happens if provider doesn't respond to `requestToken()`?
- documentation needs to be added for the new `onTokenSync` hook
- no built-in periodic validation yet _(still could be implemented outside of Hocuspocus context...)_