### PR TITLE
docs: mention requirement to call attach() when passing websocketProvider instead of url

### DIFF
--- a/docs/provider/configuration.md
+++ b/docs/provider/configuration.md
@@ -38,3 +38,7 @@ tableOfContents: true
 ## Usage
 
 There is not much required to set up the provider, a simple example can be found in [Getting started](/getting-started#frontend)
+
+### Sharing a websocket between providers
+
+You can share a `HocuspocusProviderWebsocket` instance between several `HocuspocusProviders` by passing `websocketProvider` instead of `url` when configuring the provider. If you do that, you need to call `.attach()` manually on the provider once you want it to attach and start syncing.


### PR DESCRIPTION
As mentioned in this issue, but apparently not documented anywhere else yet: https://github.com/ueberdosis/hocuspocus/issues/913#issuecomment-2815270137

Spent way too much time trying to figure out why our hocuspocus provider just wasn't doing anything anymore after upgrading to 3.1, hoping to spare others with this change. I put this in the place where it seemed most logical to me, feel free to let me know if it should also be mentioned somewhere else or moved.