### PR TITLE
Update publishing workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,6 @@ jobs:
 
       - run: npm run publish
         if: "!contains(github.ref, '-rc.')"
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - run: npm run publish:pre
         if: "contains(github.ref, '-rc.')"
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
To publish new versions of Hocuspocus packages on NPM, trusted publishing is necessary and this pull request changes everything needed:

- Add permissions to workflow
- Install a pinned version of npm CLI >= 11.5.1
- Remove old usage of secret NPM_TOKEN, because classic NPM tokens aren't working since December 9, 2025