### PR TITLE
fix(server): Send permission denied event when token sync callback throws

### DIFF
--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -269,6 +269,11 @@ export class ClientConnection {
 			} catch (err: any) {
 				console.error(err);
 				const error = { ...Unauthorized, ...err };
+				// Also send permission denied event so provider calls onAuthenticationFailed hook
+				const message = new OutgoingMessage(documentName).writePermissionDenied(
+					error.reason ?? "permission-denied",
+				);
+				this.websocket.send(message.toUint8Array());
 				connection.close({ code: error.code, reason: error.reason });
 			}
 		});


### PR DESCRIPTION
# Problem

Token synchronization was introduced in #1001 . However, when the user-provided `tokenSyncCallback` throws, indicating a failed token validation attempt, current behavior is to just close the websocket connection. This prevents onAuthenticationFailed hooks in the provider from being called. Instead, `onAuthenticationFailed` is only called after the client attempts to reconnect to the server after some duration.

# Solution

Before closing the websocket connection on a failed token validation attempt, we first send a permission denied message back to the client and then close the connection. This causes the provider to call onAuthenticationFailed hooks which is expected behavior. 