### PR TITLE
fix: validate close code is a number 

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -245,7 +245,7 @@ export class Connection<Context = any> {
 					e,
 				);
 				this.close({
-					code: "code" in e ? e.code : ResetConnection.code,
+					code: "code" in e && typeof e.code === 'number' ? e.code : ResetConnection.code,
 					reason: "reason" in e ? e.reason : ResetConnection.reason,
 				});
 			}


### PR DESCRIPTION
### Problem Statement

- When the caught error has a string error.code, it gets passed through to the WebSocket close handler which requires a numeric close code. This causes an uncaught TypeError that crashes and restarts the server.

### Scope of Work

- Validates the close code is a number before passing it to WebSocket.close(), falling back to Forbidden.code when it is not

See: https://github.com/ueberdosis/hocuspocus/issues/1063
