### PR TITLE
feat: session awareness

### DIFF
--- a/RELEASE_NOTES_V4.md
+++ b/RELEASE_NOTES_V4.md
@@ -55,6 +55,7 @@ Hook payloads now use the web-standard `Request` and `Headers` objects instead o
 - **`onLoadDocument` now accepts `Uint8Array` returns** -- extensions can return raw Yjs updates instead of constructing a full `Y.Doc`, simplifying storage extensions
 - **`handleConnection()` returns `ClientConnection`** -- enables programmatic access to the connection lifecycle for custom integrations
 - **Ordered message processing** -- messages are queued and processed sequentially per connection
+- **Session awareness** -- multiple providers can now share a single WebSocket connection with the same document name via session-aware multiplexing. Each provider gets a unique `sessionId`, enabling isolated authentication and document sessions on one socket. Enabled by default (`sessionAwareness: true`); set to `false` only when connecting to a v3 server.
 - **Auth retry support** -- failed authentication now properly cleans up state, allowing clients to retry without reconnecting
 - **DirectConnection context** -- `openDirectConnection(documentName, context)` now accepts and propagates a context object
 - **Store hooks on all changes** -- `onStoreDocument` is now triggered on any document change (not just WebSocket-originated ones), with explicit opt-out via `skipStoreHooks` on `LocalTransactionOrigin`
@@ -363,9 +364,21 @@ const server = Server.configure({
 });
 ```
 
-## 11. Provider Changes (Non-Breaking)
+## 11. Provider: Session Awareness (Default On)
 
-No code changes are required in your provider setup.
+The provider now enables `sessionAwareness` by default (`true`). This allows multiple providers to share a single WebSocket connection with the same document name via session-aware multiplexing. Each provider embeds a unique `sessionId` in messages, so the server can isolate sessions.
+
+**If you are connecting to a v3 server**, disable it explicitly:
+
+```typescript
+const provider = new HocuspocusProvider({
+  url: 'ws://localhost:1234',
+  name: 'my-document',
+  sessionAwareness: false, // required for v3 server compatibility
+});
+```
+
+No changes are needed when connecting to a v4 server.
 
 ## Summary Checklist
 
@@ -380,4 +393,5 @@ No code changes are required in your provider setup.
 - [ ] Update transaction origin checks to use `isTransactionOrigin()` and `.source`
 - [ ] If using SQLite extension: replace `sqlite3` with `better-sqlite3`
 - [ ] If using custom `handleConnection`: update to new signature and `Request` type
+- [ ] If connecting to a v3 server: set `sessionAwareness: false` on the provider
 - [ ] Test your extensions and hooks thoroughly

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth.ts";
 export * from "./CloseEvents.ts";
 export * from "./awarenessStatesToArray.ts";
+export * from "./routingKey.ts";
 export * from "./types.ts";

--- a/packages/common/src/routingKey.ts
+++ b/packages/common/src/routingKey.ts
@@ -1,0 +1,11 @@
+const SEPARATOR = '\0';
+
+export function makeRoutingKey(documentName: string, sessionId: string): string {
+	return documentName + SEPARATOR + sessionId;
+}
+
+export function parseRoutingKey(key: string): { documentName: string; sessionId: string | null } {
+	const idx = key.indexOf(SEPARATOR);
+	if (idx === -1) return { documentName: key, sessionId: null };
+	return { documentName: key.substring(0, idx), sessionId: key.substring(idx + 1) };
+}

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -1,4 +1,4 @@
-import { awarenessStatesToArray } from "@hocuspocus/common";
+import { awarenessStatesToArray, makeRoutingKey, parseRoutingKey } from "@hocuspocus/common";
 import { Awareness, removeAwarenessStates } from "y-protocols/awareness";
 import * as Y from "yjs";
 import EventEmitter from "./EventEmitter.ts";
@@ -78,6 +78,18 @@ export interface CompleteHocuspocusProviderConfiguration {
 	websocketProvider: HocuspocusProviderWebsocket;
 
 	/**
+	 * Enable session-aware multiplexing. When true, the provider embeds a unique
+	 * sessionId in the documentName field of every message, allowing multiple
+	 * providers with the same document name on a single WebSocket connection.
+	 *
+	 * Only set this to `false` when connecting to a v3 server that does not
+	 * support session awareness.
+	 *
+	 * Default: true
+	 */
+	sessionAwareness: boolean;
+
+	/**
 	 * Force syncing the document in the defined interval.
 	 */
 	forceSyncInterval: false | number;
@@ -111,6 +123,7 @@ export class HocuspocusProvider extends EventEmitter {
 		// @ts-ignore
 		awareness: undefined,
 		token: null,
+		sessionAwareness: true,
 		forceSyncInterval: false,
 		onAuthenticated: () => null,
 		onAuthenticationFailed: () => null,
@@ -141,6 +154,23 @@ export class HocuspocusProvider extends EventEmitter {
 	manageSocket = false;
 
 	private _isAttached = false;
+
+	/**
+	 * Unique session identifier for this provider instance.
+	 * Used for multiplexing multiple providers with the same document name on a single WebSocket.
+	 */
+	sessionId: string = Math.random().toString(36).slice(2);
+
+	/**
+	 * The effective name used as the first VarString in messages.
+	 * When `sessionAwareness` is enabled, returns a composite key (documentName\0sessionId).
+	 * Otherwise, returns the plain document name.
+	 */
+	get effectiveName(): string {
+		return this.configuration.sessionAwareness
+			? makeRoutingKey(this.configuration.name, this.sessionId)
+			: this.configuration.name;
+	}
 
 	intervals: any = {
 		forceSync: null,
@@ -279,7 +309,7 @@ export class HocuspocusProvider extends EventEmitter {
 
 		this.send(SyncStepOneMessage, {
 			document: this.document,
-			documentName: this.configuration.name,
+			documentName: this.effectiveName,
 		});
 	}
 
@@ -303,7 +333,7 @@ export class HocuspocusProvider extends EventEmitter {
 
 	sendStateless(payload: string) {
 		this.send(StatelessMessage, {
-			documentName: this.configuration.name,
+			documentName: this.effectiveName,
 			payload,
 		});
 	}
@@ -321,7 +351,7 @@ export class HocuspocusProvider extends EventEmitter {
 
 		this.send(AuthenticationMessage, {
 			token: token ?? "",
-			documentName: this.configuration.name,
+			documentName: this.effectiveName,
 		});
 	}
 
@@ -331,7 +361,7 @@ export class HocuspocusProvider extends EventEmitter {
 		}
 
 		this.incrementUnsyncedChanges();
-		this.send(UpdateMessage, { update, documentName: this.configuration.name });
+		this.send(UpdateMessage, { update, documentName: this.effectiveName });
 	}
 
 	awarenessUpdateHandler({ added, updated, removed }: any, origin: any) {
@@ -340,7 +370,7 @@ export class HocuspocusProvider extends EventEmitter {
 		this.send(AwarenessMessage, {
 			awareness: this.awareness,
 			clients: changedClients,
-			documentName: this.configuration.name,
+			documentName: this.effectiveName,
 		});
 	}
 
@@ -413,14 +443,14 @@ export class HocuspocusProvider extends EventEmitter {
 
 		this.send(SyncStepOneMessage, {
 			document: this.document,
-			documentName: this.configuration.name,
+			documentName: this.effectiveName,
 		});
 
 		if (this.awareness && this.awareness.getLocalState() !== null) {
 			this.send(AwarenessMessage, {
 				awareness: this.awareness,
 				clients: [this.document.clientID],
-				documentName: this.configuration.name,
+				documentName: this.effectiveName,
 			});
 		}
 	}
@@ -437,9 +467,11 @@ export class HocuspocusProvider extends EventEmitter {
 	onMessage(event: MessageEvent) {
 		const message = new IncomingMessage(event.data);
 
-		const documentName = message.readVarString();
+		const rawKey = message.readVarString();
+		// Extract actual documentName from potentially composite routing key
+		const { documentName } = parseRoutingKey(rawKey);
 
-		message.writeVarString(documentName);
+		message.writeVarString(this.effectiveName);
 
 		this.emit("message", { event, message: new IncomingMessage(event.data) });
 

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -175,7 +175,7 @@ export class Hocuspocus<Context = any> {
 				return;
 			}
 
-			document.connections.forEach(({ connection }) => {
+			document.connections.forEach((_clients, connection) => {
 				connection.close(ResetConnection);
 			});
 		});

--- a/playground/backend/package.json
+++ b/playground/backend/package.json
@@ -34,6 +34,6 @@
 	"devDependencies": {
 		"@types/jsonwebtoken": "^9.0.1",
 		"@types/koa": "^2.13.5",
-		"nodemon": "^3.1.7"
+		"nodemon": "^3.1.14"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: ^2.13.5
         version: 2.15.0
       nodemon:
-        specifier: ^3.1.7
-        version: 3.1.11
+        specifier: ^3.1.14
+        version: 3.1.14
 
   playground/frontend:
     dependencies:
@@ -3861,10 +3861,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.2.0:
-    resolution: {integrity: sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -4011,8 +4007,8 @@ packages:
   node-machine-id@1.1.12:
     resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
 
-  nodemon@3.1.11:
-    resolution: {integrity: sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==}
+  nodemon@3.1.14:
+    resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9229,10 +9225,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.0:
-    dependencies:
-      brace-expansion: 5.0.2
-
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.2
@@ -9386,12 +9378,12 @@ snapshots:
 
   node-machine-id@1.1.12: {}
 
-  nodemon@3.1.11:
+  nodemon@3.1.14:
     dependencies:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 10.2.0
+      minimatch: 10.2.4
       pstree.remy: 1.1.8
       semver: 7.7.4
       simple-update-notifier: 2.0.0

--- a/tests/server/onAuthenticate.ts
+++ b/tests/server/onAuthenticate.ts
@@ -303,13 +303,13 @@ test("onAuthenticate readonly auth only affects 1 doc (when multiplexing)", asyn
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	t.is(
-		server.documents.get("doc1")!.connections.values().next().value!.connection
+		server.documents.get("doc1")!.connections.keys().next().value!
 			.readOnly,
 		true,
 	);
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	t.is(
-		server.documents.get("doc2")!.connections.values().next().value!.connection
+		server.documents.get("doc2")!.connections.keys().next().value!
 			.readOnly,
 		false,
 	);

--- a/tests/server/onConnect.ts
+++ b/tests/server/onConnect.ts
@@ -74,9 +74,9 @@ test("sets the provider to readOnly", async (t) => {
 
 		newHocuspocusProvider(t, server, {
 			onSynced() {
-				server.documents.get("hocuspocus-test")?.connections.forEach((conn) => {
-					t.is(conn.connection.readOnly, true);
-				});
+				for (const connection of server.documents.get("hocuspocus-test")?.connections.keys() ?? []) {
+					t.is(connection.readOnly, true);
+				}
 
 				resolve("done");
 			},

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -69,9 +69,9 @@ test("sets the provider to readOnly", async (t) => {
 
 		newHocuspocusProvider(t, server, {
 			onSynced() {
-				server.documents.get("hocuspocus-test")?.connections.forEach((conn) => {
-					t.is(conn.connection.readOnly, true);
-				});
+				for (const connection of server.documents.get("hocuspocus-test")?.connections.keys() ?? []) {
+					t.is(connection.readOnly, true);
+				}
 				resolve("done");
 			},
 		});

--- a/tests/server/onTokenSync.ts
+++ b/tests/server/onTokenSync.ts
@@ -168,7 +168,7 @@ test('server requestToken: executes onTokenSync when server requests token after
 
     const document = server.documents.get('hocuspocus-test')
     if (document) {
-      const connection = document.connections.values().next().value?.connection
+      const connection = document.connections.keys().next().value
       if (connection) {
         connection.requestToken()
       }
@@ -204,7 +204,7 @@ test('server requestToken: executes onTokenSync from custom extension when serve
 
     const document = server.documents.get('hocuspocus-test')
     if (document) {
-      const connection = document.connections.values().next().value?.connection
+      const connection = document.connections.keys().next().value
       if (connection) {
         connection.requestToken()
       }
@@ -239,7 +239,7 @@ test('server requestToken: onTokenSync receives correct token when server reques
     // Now trigger token sync request from server
     const document = server.documents.get('hocuspocus-test')
     if (document) {
-      const connection = document.connections.values().next().value?.connection
+      const connection = document.connections.keys().next().value
       if (connection) {
         connection.requestToken()
       }
@@ -293,8 +293,8 @@ test('server requestToken: onTokenSync works with multiple documents when server
     await sleep(100)
 
     // Now trigger token sync requests from server for both documents
-    const doc1Connection = server.documents.get(doc1)?.connections.values().next().value?.connection
-    const doc2Connection = server.documents.get(doc2)?.connections.values().next().value?.connection
+    const doc1Connection = server.documents.get(doc1)?.connections.keys().next().value
+    const doc2Connection = server.documents.get(doc2)?.connections.keys().next().value
 
     if (doc1Connection) doc1Connection.requestToken()
     if (doc2Connection) doc2Connection.requestToken()
@@ -324,7 +324,7 @@ test('server requestToken: onTokenSync works with readonly connections when serv
     // Now trigger token sync request from server
     const document = server.documents.get('hocuspocus-test')
     if (document) {
-      const connection = document.connections.values().next().value?.connection
+      const connection = document.connections.keys().next().value
       if (connection) {
         connection.requestToken()
       }
@@ -356,7 +356,7 @@ test('server requestToken: failure of onTokenSync should close the connection', 
 
     const document = server.documents.get('hocuspocus-test')
     if (document) {
-      const connection = document.connections.values().next().value?.connection
+      const connection = document.connections.keys().next().value
       if (connection) {
         connection.requestToken()
       }

--- a/tests/server/sessionAwareness.ts
+++ b/tests/server/sessionAwareness.ts
@@ -1,0 +1,329 @@
+import { parseRoutingKey } from "@hocuspocus/common";
+import type { onAuthenticatePayload, connectedPayload } from "@hocuspocus/server";
+import test from "ava";
+import { readVarString, createDecoder } from "lib0/decoding";
+import {
+	newHocuspocus,
+	newHocuspocusProvider,
+	newHocuspocusProviderWebsocket,
+} from "../utils/index.ts";
+import { retryableAssertion } from "../utils/retryableAssertion.ts";
+
+test("sessionAwareness: two providers with same doc name both connect successfully", async (t) => {
+	await new Promise(async (resolve) => {
+		let connectedCount = 0;
+
+		const server = await newHocuspocus(t, {
+			async onAuthenticate() {
+				return true;
+			},
+		});
+
+		const socket = newHocuspocusProviderWebsocket(t, server);
+
+		const provider1 = newHocuspocusProvider(
+			t,
+			server,
+			{
+				websocketProvider: socket,
+				token: "token-1",
+				name: "shared-doc",
+				sessionAwareness: true,
+				onAuthenticated() {
+					connectedCount++;
+					if (connectedCount === 2) {
+						resolve("done");
+					}
+				},
+			},
+		);
+
+		const provider2 = newHocuspocusProvider(
+			t,
+			server,
+			{
+				websocketProvider: socket,
+				token: "token-2",
+				name: "shared-doc",
+				sessionAwareness: true,
+				onAuthenticated() {
+					connectedCount++;
+					if (connectedCount === 2) {
+						resolve("done");
+					}
+				},
+			},
+		);
+
+		t.truthy(provider1);
+		t.truthy(provider2);
+	});
+});
+
+test("sessionAwareness: auth failure isolation - provider A fails, provider B succeeds", async (t) => {
+	const server = await newHocuspocus(t, {
+		async onAuthenticate({ token }: onAuthenticatePayload) {
+			if (token === "bad-token") {
+				throw new Error("unauthorized");
+			}
+			return true;
+		},
+	});
+
+	const socket = newHocuspocusProviderWebsocket(t, server);
+
+	const providerFail = newHocuspocusProvider(
+		t,
+		server,
+		{
+			websocketProvider: socket,
+			token: "bad-token",
+			name: "shared-doc",
+			sessionAwareness: true,
+			onAuthenticated() {
+				t.fail("providerFail should not authenticate");
+			},
+		},
+	);
+
+	const providerOK = newHocuspocusProvider(
+		t,
+		server,
+		{
+			websocketProvider: socket,
+			token: "good-token",
+			name: "shared-doc",
+			sessionAwareness: true,
+			onAuthenticationFailed() {
+				t.fail("providerOK should not fail auth");
+			},
+		},
+	);
+
+	await retryableAssertion(t, (tt) => {
+		tt.is(providerFail.isAuthenticated, false);
+		tt.is(providerOK.isAuthenticated, true);
+		tt.is(server.getDocumentsCount(), 1);
+	});
+});
+
+test("sessionAwareness: false - two providers with same name on same socket throws when first is authenticated", async (t) => {
+	const server = await newHocuspocus(t, {
+		async onAuthenticate() {
+			return true;
+		},
+	});
+
+	const socket = newHocuspocusProviderWebsocket(t, server);
+
+	const provider1 = newHocuspocusProvider(t, server, {
+		websocketProvider: socket,
+		token: "token",
+		name: "same-doc",
+		sessionAwareness: false,
+	});
+
+	await retryableAssertion(t, (tt) => {
+		tt.is(provider1.isAuthenticated, true);
+	});
+
+	// Now that provider1 is authenticated, attaching a second with the same name should throw
+	t.throws(() => {
+		newHocuspocusProvider(t, server, {
+			websocketProvider: socket,
+			token: "token",
+			name: "same-doc",
+			sessionAwareness: false,
+		});
+	});
+});
+
+test("sessionAwareness: connection has correct sessionId", async (t) => {
+	await new Promise(async (resolve) => {
+		const server = await newHocuspocus(t, {
+			async onAuthenticate() {
+				return true;
+			},
+			async connected({ connection }: connectedPayload) {
+				t.truthy(connection.sessionId);
+				t.is(typeof connection.sessionId, "string");
+				t.truthy(connection.sessionId!.length > 0);
+				resolve("done");
+			},
+		});
+
+		const socket = newHocuspocusProviderWebsocket(t, server);
+
+		newHocuspocusProvider(t, server, {
+			websocketProvider: socket,
+			token: "test-token",
+			name: "session-doc",
+			sessionAwareness: true,
+		});
+	});
+});
+
+test("sessionAwareness: connection has correct providerVersion", async (t) => {
+	await new Promise(async (resolve) => {
+		const server = await newHocuspocus(t, {
+			async onAuthenticate() {
+				return true;
+			},
+			async connected({ connection }: connectedPayload) {
+				t.is(typeof connection.providerVersion, "string");
+				t.truthy(connection.providerVersion!.length > 0);
+				resolve("done");
+			},
+		});
+
+		const socket = newHocuspocusProviderWebsocket(t, server);
+
+		newHocuspocusProvider(t, server, {
+			websocketProvider: socket,
+			token: "test-token",
+			name: "session-doc",
+			sessionAwareness: true,
+		});
+	});
+});
+
+test("sessionAwareness: all outgoing messages from provider include sessionId in routing key", async (t) => {
+	const server = await newHocuspocus(t, {
+		async onAuthenticate() {
+			return true;
+		},
+	});
+
+	const socket = newHocuspocusProviderWebsocket(t, server);
+
+	const sentMessages: Uint8Array[] = [];
+	const originalSend = socket.webSocket!.send.bind(socket.webSocket!);
+
+	const provider = newHocuspocusProvider(t, server, {
+		websocketProvider: socket,
+		token: "test-token",
+		name: "session-doc",
+		sessionAwareness: true,
+	});
+
+	await retryableAssertion(t, (tt) => {
+		tt.is(provider.isSynced, true);
+	});
+
+	// Monkey-patch send to capture outgoing messages
+	socket.webSocket!.send = (data: any) => {
+		if (data instanceof Uint8Array || data instanceof ArrayBuffer) {
+			sentMessages.push(new Uint8Array(data));
+		}
+		originalSend(data);
+	};
+
+	// Trigger a document update which causes the provider to send an UpdateMessage
+	provider.document.getMap("test").set("key", "value");
+
+	await retryableAssertion(t, (tt) => {
+		tt.true(sentMessages.length > 0, "should have captured outgoing messages");
+
+		for (const msg of sentMessages) {
+			const decoder = createDecoder(msg);
+			const routingKey = readVarString(decoder);
+			const { documentName, sessionId } = parseRoutingKey(routingKey);
+			tt.is(documentName, "session-doc", `message routing key should contain correct document name, got: ${routingKey}`);
+			tt.truthy(sessionId, `every outgoing message should include a sessionId in the routing key, got: ${routingKey}`);
+		}
+	});
+});
+
+test("sessionAwareness: SyncStep2 reply includes sessionId in routing key", async (t) => {
+	const server = await newHocuspocus(t, {
+		async onAuthenticate() {
+			return true;
+		},
+	});
+
+	const socket = newHocuspocusProviderWebsocket(t, server);
+
+	const provider = newHocuspocusProvider(t, server, {
+		websocketProvider: socket,
+		token: "test-token",
+		name: "sync-reply-doc",
+		sessionAwareness: true,
+	});
+
+	await retryableAssertion(t, (tt) => {
+		tt.is(provider.isSynced, true);
+	});
+
+	// Capture all outgoing messages
+	const sentMessages: Uint8Array[] = [];
+	const originalSend = socket.webSocket!.send.bind(socket.webSocket!);
+	socket.webSocket!.send = (data: any) => {
+		if (data instanceof Uint8Array || data instanceof ArrayBuffer) {
+			sentMessages.push(new Uint8Array(data));
+		}
+		originalSend(data);
+	};
+
+	// Force a sync which triggers SyncStep1 -> server replies with SyncStep1 -> provider replies with SyncStep2
+	provider.forceSync();
+
+	await retryableAssertion(t, (tt) => {
+		// We expect at least the SyncStep1 from forceSync plus the SyncStep2 reply
+		tt.true(sentMessages.length >= 2, `should have at least 2 messages, got ${sentMessages.length}`);
+
+		for (const msg of sentMessages) {
+			const decoder = createDecoder(msg);
+			const routingKey = readVarString(decoder);
+			const { sessionId } = parseRoutingKey(routingKey);
+			tt.truthy(sessionId, `message should include sessionId, got routing key: ${routingKey}`);
+		}
+	});
+});
+
+test("sessionAwareness: providers with different doc names still work without sessionAwareness", async (t) => {
+	await new Promise(async (resolve) => {
+		let connectedCount = 0;
+
+		const server = await newHocuspocus(t, {
+			async onAuthenticate() {
+				return true;
+			},
+		});
+
+		const socket = newHocuspocusProviderWebsocket(t, server);
+
+		newHocuspocusProvider(
+			t,
+			server,
+			{
+				websocketProvider: socket,
+				token: "token-1",
+				name: "doc-1",
+				onAuthenticated() {
+					connectedCount++;
+					if (connectedCount === 2) {
+						resolve("done");
+					}
+				},
+			},
+		);
+
+		newHocuspocusProvider(
+			t,
+			server,
+			{
+				websocketProvider: socket,
+				token: "token-2",
+				name: "doc-2",
+				onAuthenticated() {
+					connectedCount++;
+					if (connectedCount === 2) {
+						resolve("done");
+					}
+				},
+			},
+		);
+
+		t.pass();
+	});
+});


### PR DESCRIPTION
Adds session awareness. The current provider<>server connection purely relies on the document name to route messages to the correct message receiver (both in provider and server). Sometimes this causes issues (for example during rerenders in the frontend, or when a provider reconnects really fast. 

This PR introduces session awareness, which can be enabled in the provider and is fully backward compatible (except if you are using `\0` in your document names).