### PR TITLE
fix(server): wrap awareness origin as TransactionOrigin

### DIFF
--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -7,7 +7,12 @@ import {
 import { Doc, applyUpdate, encodeStateAsUpdate } from "yjs";
 import type Connection from "./Connection.ts";
 import { OutgoingMessage } from "./OutgoingMessage.ts";
-import type { AwarenessUpdate } from "./types.ts";
+import { isTransactionOrigin } from "./types.ts";
+import type {
+	AwarenessUpdate,
+	ConnectionTransactionOrigin,
+	TransactionOrigin,
+} from "./types.ts";
 
 export class Document extends Doc {
 	awareness: Awareness;
@@ -180,7 +185,10 @@ export class Document extends Doc {
 	 * Apply the given awareness update
 	 */
 	applyAwarenessUpdate(connection: Connection, update: Uint8Array): Document {
-		applyAwarenessUpdate(this.awareness, update, connection);
+		applyAwarenessUpdate(this.awareness, update, {
+			source: "connection",
+			connection,
+		} satisfies ConnectionTransactionOrigin);
 
 		return this;
 	}
@@ -191,9 +199,14 @@ export class Document extends Doc {
 	 */
 	private handleAwarenessUpdate(
 		{ added, updated, removed }: AwarenessUpdate,
-		originConnection: Connection | null,
+		origin: TransactionOrigin | null,
 	): Document {
 		const changedClients = added.concat(updated, removed);
+
+		const originConnection: Connection | null =
+			isTransactionOrigin(origin) && origin.source === "connection"
+				? origin.connection
+				: null;
 
 		if (originConnection !== null) {
 			const entry = this.connections.get(originConnection);

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -15,7 +15,11 @@ import type Connection from "./Connection.ts";
 import type Document from "./Document.ts";
 import type { IncomingMessage } from "./IncomingMessage.ts";
 import { OutgoingMessage } from "./OutgoingMessage.ts";
-import { MessageType, type TransactionOrigin } from "./types.ts";
+import {
+	MessageType,
+	type ConnectionTransactionOrigin,
+	type TransactionOrigin,
+} from "./types.ts";
 
 export class MessageReceiver {
 	message: IncomingMessage;
@@ -62,10 +66,17 @@ export class MessageReceiver {
 				break;
 			}
 			case MessageType.Awareness: {
+				const origin: TransactionOrigin = connection
+					? ({
+							source: "connection",
+							connection,
+						} satisfies ConnectionTransactionOrigin)
+					: (this.defaultTransactionOrigin ?? { source: "local" });
+
 				applyAwarenessUpdate(
 					document.awareness,
 					message.readVarUint8Array(),
-					connection ?? null,
+					origin,
 				);
 
 				break;

--- a/tests/server/onAwarenessUpdate.ts
+++ b/tests/server/onAwarenessUpdate.ts
@@ -55,3 +55,31 @@ test('executes the onAwarenessUpdate callback from a custom extension', async t 
     })
   })
 })
+
+test('forwards the originating connection on onAwarenessUpdate', async t => {
+  await new Promise(async resolve => {
+    let resolved = false
+
+    const server = await newHocuspocus(t, {
+      async onAuthenticate() {
+        return { user: { id: 'u-1', displayName: 'Test User' } }
+      },
+      async onAwarenessUpdate({ connection, states }) {
+        if (resolved || states.length === 0) return
+        resolved = true
+
+        t.truthy(connection, 'connection should be defined for client-originated awareness updates')
+        t.is((connection?.context as { user: { id: string } } | undefined)?.user?.id, 'u-1')
+
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      token: 'anything',
+      onConnect() {
+        provider.setAwarenessField('foo', 'bar')
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`onAwarenessUpdate({ connection })` is always `undefined` in v4. The awareness listener in `Hocuspocus.ts` reads it via `isTransactionOrigin(origin)`, but the producers (`MessageReceiver` awareness branch and `Document.applyAwarenessUpdate`) pass the raw `Connection`. The type guard returns `false`, so the connection is never forwarded to the hook and server-side awareness work that depends on the per-update authenticated user cannot function.

## Fix

Wrap origin as `{ source: 'connection', connection }` at the producer sites, matching the sync handlers in the same `MessageReceiver`. Update `Document.handleAwarenessUpdate` to extract the connection through the existing type guard. Tighten the related parameter types with `satisfies ConnectionTransactionOrigin` and `TransactionOrigin | null` so future producers cannot regress.

I suspect this matches the original v4 intent: `Hocuspocus.ts`'s awareness listener was already written for `TransactionOrigin`, the sync handlers already wrap, and the previous `originConnection: Connection | null` parameter on `handleAwarenessUpdate` looks like a leftover pre-v4 signature. The y-protocols `origin: any` typing hid the inconsistency from the compiler.

## Soft API break

Listeners attached directly via `document.awareness.on('update', ...)` now receive a `TransactionOrigin` (or `{ source: 'local' }` for non-connection origins) instead of a raw `Connection`. Migration:

```ts
const conn = isTransactionOrigin(origin) && origin.source === 'connection'
  ? origin.connection
  : null
```

The supported `onAwarenessUpdate` hook is unaffected and gains the resolved `payload.connection`.

## Alternative

If full backwards compatibility is preferred, I can instead make the consumer side tolerant of both raw `Connection` and wrapped `TransactionOrigin`, leaving the producers untouched. Happy to switch.
