### PR TITLE
feat(server): add beforeHandleAwareness hook

### DIFF
--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -21,6 +21,11 @@ export class Document extends Doc {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		onUpdate: (document: Document, origin: unknown, update: Uint8Array) => {},
 		beforeBroadcastStateless: (document: Document, stateless: string) => {},
+		beforeHandleAwareness: (
+			document: Document,
+			states: Map<number, Record<string, any>>,
+			transactionOrigin: unknown,
+		) => Promise.resolve(),
 	};
 
 	connections: Map<
@@ -96,6 +101,27 @@ export class Document extends Doc {
 		callback: (document: Document, stateless: string) => void,
 	): Document {
 		this.callbacks.beforeBroadcastStateless = callback;
+
+		return this;
+	}
+
+	/**
+	 * Set a callback that will be triggered before an inbound awareness update
+	 * is applied to this document's awareness state. The callback receives the
+	 * document, the decoded per-client states as a mutable `Map`, and the
+	 * `TransactionOrigin` that will be forwarded to `applyAwarenessUpdate`.
+	 * Use `isTransactionOrigin(origin)` to discriminate sources. Mutate the
+	 * map in place (set/delete/field changes) to rewrite the update, or throw
+	 * to reject it entirely.
+	 */
+	beforeHandleAwareness(
+		callback: (
+			document: Document,
+			states: Map<number, Record<string, any>>,
+			transactionOrigin: unknown,
+		) => Promise<any>,
+	): Document {
+		this.callbacks.beforeHandleAwareness = callback;
 
 		return this;
 	}

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -46,6 +46,7 @@ export class Hocuspocus<Context = any> {
 		onConnect: () => new Promise((r) => r(null)),
 		connected: () => new Promise((r) => r(null)),
 		beforeHandleMessage: () => new Promise((r) => r(null)),
+		beforeHandleAwareness: () => new Promise<void>((r) => r()),
 		beforeSync: () => new Promise((r) => r(null)),
 		beforeBroadcastStateless: () => new Promise((r) => r(null)),
 		onStateless: () => new Promise((r) => r(null)),
@@ -112,6 +113,7 @@ export class Hocuspocus<Context = any> {
 			onLoadDocument: this.configuration.onLoadDocument,
 			afterLoadDocument: this.configuration.afterLoadDocument,
 			beforeHandleMessage: this.configuration.beforeHandleMessage,
+			beforeHandleAwareness: this.configuration.beforeHandleAwareness,
 			beforeBroadcastStateless: this.configuration.beforeBroadcastStateless,
 			beforeSync: this.configuration.beforeSync,
 			onStateless: this.configuration.onStateless,
@@ -435,6 +437,31 @@ export class Hocuspocus<Context = any> {
 				this.hooks("beforeBroadcastStateless", hookPayload);
 			},
 		);
+
+		document.beforeHandleAwareness((document, states, transactionOrigin) => {
+			const connection =
+				isTransactionOrigin(transactionOrigin) &&
+				transactionOrigin.source === "connection"
+					? transactionOrigin.connection
+					: undefined;
+			const request = connection?.request;
+			return this.hooks("beforeHandleAwareness", {
+				awareness: document.awareness,
+				clientsCount: document.getConnectionsCount(),
+				context: connection?.context,
+				document,
+				documentName: document.name,
+				instance: this,
+				requestHeaders: request?.headers ?? new Headers(),
+				requestParameters: request
+					? getParameters(request)
+					: new URLSearchParams(),
+				socketId: connection?.socketId ?? "",
+				transactionOrigin,
+				connection,
+				states,
+			});
+		});
 
 		document.awareness.on(
 			"update",

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -1,7 +1,11 @@
 import { AuthMessageType } from "@hocuspocus/common";
 import * as decoding from "lib0/decoding";
 import { readVarString } from "lib0/decoding";
-import { applyAwarenessUpdate } from "y-protocols/awareness";
+import {
+	Awareness,
+	applyAwarenessUpdate,
+	encodeAwarenessUpdate,
+} from "y-protocols/awareness";
 import {
 	messageYjsSyncStep1,
 	messageYjsSyncStep2,
@@ -66,6 +70,8 @@ export class MessageReceiver {
 				break;
 			}
 			case MessageType.Awareness: {
+				let update = message.readVarUint8Array();
+
 				const origin: TransactionOrigin = connection
 					? ({
 							source: "connection",
@@ -73,11 +79,26 @@ export class MessageReceiver {
 						} satisfies ConnectionTransactionOrigin)
 					: (this.defaultTransactionOrigin ?? { source: "local" });
 
-				applyAwarenessUpdate(
-					document.awareness,
-					message.readVarUint8Array(),
+				// Decode the inbound update into a scratch Awareness so the hook
+				// chain sees a high-level Map<clientId, state>. Mutations to that
+				// map (including `set`, `delete`, and field changes on each state
+				// object) are picked up by the re-encode below and forwarded as
+				// the broadcast payload. Hooks may also throw to reject the
+				// update entirely.
+				const scratch = new Awareness(new Y.Doc());
+				applyAwarenessUpdate(scratch, update, null);
+
+				await document.callbacks.beforeHandleAwareness(
+					document,
+					scratch.getStates(),
 					origin,
 				);
+
+				update = encodeAwarenessUpdate(scratch, [
+					...scratch.getStates().keys(),
+				]);
+
+				applyAwarenessUpdate(document.awareness, update, origin);
 
 				break;
 			}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -98,6 +98,20 @@ export interface Extension<Context = any> {
 	onLoadDocument?(data: onLoadDocumentPayload<Context>): Promise<any>;
 	afterLoadDocument?(data: afterLoadDocumentPayload<Context>): Promise<any>;
 	beforeHandleMessage?(data: beforeHandleMessagePayload<Context>): Promise<any>;
+	/**
+	 * Fired before an inbound awareness update is applied to the document's
+	 * awareness state. The hook receives the decoded per-client `states` as a
+	 * mutable `Map` keyed by Yjs clientId. Mutate the map and the contained
+	 * state objects in place to rewrite fields, drop peers (`states.delete`),
+	 * or add synthetic ones (`states.set`); mutations are reflected in the
+	 * broadcast. Throw to reject the update without applying anything.
+	 *
+	 * Multiple extensions chain naturally: each extension sees the map as
+	 * mutated by previous extensions and can mutate it further.
+	 */
+	beforeHandleAwareness?(
+		data: beforeHandleAwarenessPayload<Context>,
+	): Promise<any>;
 	beforeSync?(data: beforeSyncPayload<Context>): Promise<any>;
 	beforeBroadcastStateless?(
 		data: beforeBroadcastStatelessPayload,
@@ -126,6 +140,7 @@ export type HookName =
 	| "onLoadDocument"
 	| "afterLoadDocument"
 	| "beforeHandleMessage"
+	| "beforeHandleAwareness"
 	| "beforeBroadcastStateless"
 	| "beforeSync"
 	| "onStateless"
@@ -151,6 +166,7 @@ export type HookPayloadByName<Context = any> = {
 	onLoadDocument: onLoadDocumentPayload<Context>;
 	afterLoadDocument: afterLoadDocumentPayload<Context>;
 	beforeHandleMessage: beforeHandleMessagePayload<Context>;
+	beforeHandleAwareness: beforeHandleAwarenessPayload<Context>;
 	beforeBroadcastStateless: beforeBroadcastStatelessPayload;
 	beforeSync: beforeSyncPayload<Context>;
 	onStateless: onStatelessPayload;
@@ -324,6 +340,44 @@ export interface beforeHandleMessagePayload<Context = any> {
 	update: Uint8Array;
 	socketId: string;
 	connection: Connection<Context>;
+}
+
+export interface beforeHandleAwarenessPayload<Context = any> {
+	awareness: Awareness;
+	clientsCount: number;
+	/**
+	 * Connection context populated by `onAuthenticate`. `undefined` when the
+	 * update did not originate from a client connection (e.g. server-internal
+	 * writes via `DirectConnection`).
+	 */
+	context: Context | undefined;
+	document: Document;
+	documentName: string;
+	instance: Hocuspocus;
+	requestHeaders: Headers;
+	requestParameters: URLSearchParams;
+	/**
+	 * Per-client awareness states decoded from the inbound update, keyed by
+	 * Yjs clientId. Mutate this map in place to rewrite the update: change
+	 * fields on a state object, `states.delete(clientId)` to drop a peer, or
+	 * `states.set(clientId, ...)` to add or replace one. The encoded update
+	 * sent to peers reflects whatever the map looks like after every hook in
+	 * the chain has run.
+	 */
+	states: Map<number, Record<string, any>>;
+	socketId: string;
+	/**
+	 * The `TransactionOrigin` that will be passed to `applyAwarenessUpdate`.
+	 * Use `isTransactionOrigin(origin)` to discriminate sources. Matches the
+	 * `transactionOrigin` shape of `onAwarenessUpdatePayload`.
+	 */
+	transactionOrigin: unknown;
+	/**
+	 * Convenience shortcut: `origin.connection` when `transactionOrigin` is a
+	 * `ConnectionTransactionOrigin`, otherwise `undefined`. Matches the
+	 * `connection?` shape of `onAwarenessUpdatePayload`.
+	 */
+	connection?: Connection<Context>;
 }
 
 export interface beforeSyncPayload<Context = any> {

--- a/tests/server/beforeHandleAwareness.ts
+++ b/tests/server/beforeHandleAwareness.ts
@@ -1,0 +1,239 @@
+import test from 'ava'
+import { newHocuspocus, newHocuspocusProvider } from '../utils/index.ts'
+
+test('beforeHandleAwareness is called before the awareness state is applied', async t => {
+  await new Promise(async resolve => {
+    let resolved = false
+
+    const server = await newHocuspocus(t, {
+      async beforeHandleAwareness({ awareness, states, connection }) {
+        if (resolved) return
+        resolved = true
+
+        // The decoded states from the inbound update are exposed as a
+        // mutable Map keyed by clientId. The document's own awareness has
+        // not received the update yet.
+        t.true(states instanceof Map)
+        t.true(states.size > 0)
+        t.truthy(connection, 'connection is forwarded per call')
+        t.is(awareness.getStates().size, 0)
+
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('foo', 'bar')
+      },
+    })
+  })
+})
+
+test('mutating states in beforeHandleAwareness rewrites the update before it is applied', async t => {
+  await new Promise(async resolve => {
+    let resolved = false
+
+    const server = await newHocuspocus(t, {
+      async beforeHandleAwareness({ states }) {
+        // Stamp a server-side value over whatever the client sent.
+        for (const state of states.values()) {
+          state.user = 'Verified'
+        }
+      },
+      async onAwarenessUpdate({ states }) {
+        const v = states.find(s => s.user === 'Verified' && s.foo === 'bar')
+        if (resolved || !v) return
+        resolved = true
+
+        // Mutated value lands in awareness; original ('Spoofed') never appears.
+        t.is(v.user, 'Verified')
+        t.is(v.foo, 'bar')
+        t.falsy(states.find(s => s.user === 'Spoofed'))
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('user', 'Spoofed')
+        provider.setAwarenessField('foo', 'bar')
+      },
+    })
+  })
+})
+
+test('chaining: a second extension sees mutations made by the first', async t => {
+  await new Promise(async resolve => {
+    let resolved = false
+
+    class FirstExtension {
+      async beforeHandleAwareness({ states }: { states: Map<number, Record<string, any>> }) {
+        for (const state of states.values()) {
+          state.user = 'first'
+        }
+      }
+    }
+
+    class SecondExtension {
+      async beforeHandleAwareness({ states }: { states: Map<number, Record<string, any>> }) {
+        // Sees `first`'s mutation, appends to it.
+        for (const state of states.values()) {
+          t.is(state.user, 'first', 'sees first extension mutation')
+          state.user = `${state.user}-then-second`
+        }
+      }
+    }
+
+    const server = await newHocuspocus(t, {
+      extensions: [new FirstExtension(), new SecondExtension()],
+      async onAwarenessUpdate({ states }) {
+        const v = states.find(s => s.user === 'first-then-second')
+        if (resolved || !v) return
+        resolved = true
+
+        // Both extension mutations made it through, in order.
+        t.is(v.user, 'first-then-second')
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('user', 'unchanged-by-client')
+      },
+    })
+  })
+})
+
+test('chaining: extensions run before the config-level hook, in registration order', async t => {
+  await new Promise(async resolve => {
+    let resolved = false
+
+    class ExtensionA {
+      async beforeHandleAwareness({ states }: { states: Map<number, Record<string, any>> }) {
+        for (const state of states.values()) {
+          state.trail = `${state.trail ?? ''}A`
+        }
+      }
+    }
+
+    class ExtensionB {
+      async beforeHandleAwareness({ states }: { states: Map<number, Record<string, any>> }) {
+        for (const state of states.values()) {
+          state.trail = `${state.trail ?? ''}B`
+        }
+      }
+    }
+
+    const server = await newHocuspocus(t, {
+      extensions: [new ExtensionA(), new ExtensionB()],
+      async beforeHandleAwareness({ states }) {
+        // Config-level hook is pushed onto `extensions` as the final entry by
+        // `configure()`, so it runs AFTER both class extensions.
+        for (const state of states.values()) {
+          state.trail = `${state.trail ?? ''}C`
+        }
+      },
+      async onAwarenessUpdate({ states }) {
+        const v = states.find(s => s.trail === 'ABC')
+        if (resolved || !v) return
+        resolved = true
+
+        t.is(v.trail, 'ABC', 'extensions run first then the config-level hook')
+        resolve('done')
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('init', true)
+      },
+    })
+  })
+})
+
+test('throwing discards preceding extension mutations', async t => {
+  await new Promise(async resolve => {
+    let mutatorCalls = 0
+    let throwerCalls = 0
+    let onUpdateCalls = 0
+
+    class MutatingExtension {
+      async beforeHandleAwareness({ states }: { states: Map<number, Record<string, any>> }) {
+        mutatorCalls += 1
+        for (const state of states.values()) {
+          state.user = 'first'
+        }
+      }
+    }
+
+    class ThrowingExtension {
+      async beforeHandleAwareness() {
+        throwerCalls += 1
+        throw new Error('rejected')
+      }
+    }
+
+    const server = await newHocuspocus(t, {
+      extensions: [new MutatingExtension(), new ThrowingExtension()],
+      async onAwarenessUpdate({ states }) {
+        if (states.length > 0) onUpdateCalls += 1
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('foo', 'bar')
+      },
+    })
+
+    setTimeout(() => {
+      t.true(mutatorCalls >= 1, 'preceding extension fired')
+      t.true(throwerCalls >= 1, 'throwing extension fired')
+      t.is(onUpdateCalls, 0, 'preceding mutations are not half-applied')
+      resolve('done')
+    }, 400)
+  })
+})
+
+test('throwing aborts subsequent extensions and the config-level hook', async t => {
+  await new Promise(async resolve => {
+    let throwerCalls = 0
+    let afterThrowerCalls = 0
+    let configCalls = 0
+
+    class ThrowingExtension {
+      async beforeHandleAwareness() {
+        throwerCalls += 1
+        throw new Error('rejected')
+      }
+    }
+
+    class AfterThrowerExtension {
+      async beforeHandleAwareness() {
+        afterThrowerCalls += 1
+      }
+    }
+
+    const server = await newHocuspocus(t, {
+      extensions: [new ThrowingExtension(), new AfterThrowerExtension()],
+      async beforeHandleAwareness() {
+        configCalls += 1
+      },
+    })
+
+    const provider = newHocuspocusProvider(t, server, {
+      onConnect() {
+        provider.setAwarenessField('foo', 'bar')
+      },
+    })
+
+    setTimeout(() => {
+      t.true(throwerCalls >= 1, 'throwing extension fired')
+      t.is(afterThrowerCalls, 0, 'extensions after the throw do not run')
+      t.is(configCalls, 0, 'config-level hook does not run')
+      resolve('done')
+    }, 400)
+  })
+})


### PR DESCRIPTION
Adds a new hook that fires after decoding an inbound awareness message and before `applyAwarenessUpdate` runs. The payload exposes the per-client states as a mutable `Map<clientId, state>`. Mutations rewrite the encoded update that is then applied and broadcast; throwing rejects the update.

Use cases include server-side identity stamping (anti-spoofing), state validation, and filtering.

Payload mirrors `onAwarenessUpdatePayload`: `transactionOrigin: unknown` plus `connection?` convenience shortcut, derived via `isTransactionOrigin`. Extensions chain naturally and run before the configuration-level hook.

Follow-up to #1094 (which fixed the awareness path to wrap origin as `TransactionOrigin`).

Fixes #1095 