### PR TITLE
Feature: expose sessionAwareness in provider-react HocuspocusRoom

### DIFF
--- a/packages/provider-react/src/HocuspocusRoom.tsx
+++ b/packages/provider-react/src/HocuspocusRoom.tsx
@@ -53,6 +53,7 @@ export function HocuspocusRoom({
 	name,
 	document,
 	token,
+	sessionAwareness,
 	...eventHandlers
 }: HocuspocusRoomProps) {
 	const hocuspocusContext = useContext(HocuspocusContext);
@@ -72,6 +73,7 @@ export function HocuspocusRoom({
 				websocketProvider,
 				document,
 				token,
+				sessionAwareness,
 			}),
 	);
 
@@ -100,6 +102,7 @@ export function HocuspocusRoom({
 					websocketProvider,
 					document,
 					token,
+					sessionAwareness,
 				}),
 			);
 		}

--- a/packages/provider-react/src/types.ts
+++ b/packages/provider-react/src/types.ts
@@ -82,6 +82,17 @@ export interface HocuspocusRoomProps {
 	 * JWT token or function that returns a promise resolving to a token
 	 */
 	token?: string | (() => Promise<string>) | (() => string);
+	/**
+	 * Enable session-aware multiplexing. When true, the provider embeds a unique
+	 * sessionId in the documentName field of every message, allowing multiple
+	 * providers with the same document name on a single WebSocket connection.
+	 *
+	 * Only set this to `false` when connecting to a v3 server that does not
+	 * support session awareness.
+	 *
+	 * Default: false
+	 */
+	sessionAwareness?: boolean;
 
 	// Event handlers — all optional, called when the provider emits the corresponding event.
 	onOpen?: (data: onOpenParameters) => void;

--- a/packages/provider-react/src/types.ts
+++ b/packages/provider-react/src/types.ts
@@ -87,7 +87,7 @@ export interface HocuspocusRoomProps {
 	 * sessionId in the documentName field of every message, allowing multiple
 	 * providers with the same document name on a single WebSocket connection.
 	 *
-	 * Only set this to `false` when connecting to a v3 server that does not
+	 * Only set this to `true` when connecting to a v4 server that does 
 	 * support session awareness.
 	 *
 	 * Default: false

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -82,7 +82,7 @@ export interface CompleteHocuspocusProviderConfiguration {
 	 * sessionId in the documentName field of every message, allowing multiple
 	 * providers with the same document name on a single WebSocket connection.
 	 *
-	 * Only set this to `false` when connecting to a v3 server that does not
+	 * Only set this to `true` when connecting to a v4 server that does 
 	 * support session awareness.
 	 *
 	 * Default: false

--- a/packages/provider/src/HocuspocusProvider.ts
+++ b/packages/provider/src/HocuspocusProvider.ts
@@ -85,7 +85,7 @@ export interface CompleteHocuspocusProviderConfiguration {
 	 * Only set this to `false` when connecting to a v3 server that does not
 	 * support session awareness.
 	 *
-	 * Default: true
+	 * Default: false
 	 */
 	sessionAwareness: boolean;
 


### PR DESCRIPTION
In the docs it states sessionAwareness is default set to `true` https://github.com/ueberdosis/hocuspocus/blob/6872d08bbb2ebe8175dcfb51953481b2f4988291/packages/provider/src/HocuspocusProvider.ts#L88

But in fact its default is `false`
https://github.com/ueberdosis/hocuspocus/blob/6872d08bbb2ebe8175dcfb51953481b2f4988291/packages/provider/src/HocuspocusProvider.ts#L126

Commit: https://github.com/ueberdosis/hocuspocus/commit/3a57071517adb5c9e037fb7c0ac169ffc330df90

Therefore `HocuspocusRoom` needs the property `sessionAwareness` exposed to enable it manually. 

Changing the default to `true` would be a breaking change in my oppinion

