### PR TITLE
fix: delete debouncer timer entry before awaiting the in-flight execution

### DIFF
--- a/packages/server/src/util/debounce.ts
+++ b/packages/server/src/util/debounce.ts
@@ -22,12 +22,12 @@ export const useDebounce = () => {
 		const start = old?.start || Date.now();
 
 		const run = async () => {
+			timers.delete(id);
+
 			if (runningExecutions.has(id)) {
 				// wait for previous execution to finish
 				await runningExecutions.get(id);
 			}
-
-			timers.delete(id);
 
 			const execution = func();
 

--- a/tests/server/debounce.ts
+++ b/tests/server/debounce.ts
@@ -1,0 +1,31 @@
+import { useDebounce } from "@hocuspocus/server";
+import test from "ava";
+import { sleep } from "../utils/index.ts";
+
+test("maxDebounce does not queue an execution per call while a slow execution is in flight", async (t) => {
+	const { debounce } = useDebounce();
+
+	let executions = 0;
+	const func = async () => {
+		executions += 1;
+		// the first execution is slower than maxDebounce, simulating a
+		// database/S3 latency spike during a store
+		await sleep(executions === 1 ? 500 : 10);
+	};
+
+	// Continuous calls, like a busy collaborative document: each call resets
+	// the debounce timeout, so only the maxDebounce branch triggers executions
+	// (at most one per 200ms).
+	const end = Date.now() + 1_000;
+	while (Date.now() < end) {
+		debounce("doc", func, 50, 200);
+		await sleep(20);
+	}
+	await sleep(600); // let in-flight and queued executions finish
+
+	// ~1s of continuous calls with maxDebounce=200 should execute ~5 times.
+	// If run() suspends on the in-flight execution before deleting the timer
+	// entry, the stale entry keeps satisfying the maxDebounce age check and
+	// every call during the slow execution queues another run (~25 executions).
+	t.true(executions <= 8, `executed ${executions} times, expected ~5`);
+});


### PR DESCRIPTION
Since v3.4.0, a single `onStoreDocument` execution that takes longer than `maxDebounce` causes the server to queue one additional store **per incoming document update**, and then execute them back-to-back. Under continuous collaborative editing the storm is self-sustaining: store cadence collapses from one per `maxDebounce` to one per store-duration, indefinitely, until editing stops or the process is restarted.

We hit this in production (Hocuspocus 3.4.4, 14 concurrent users on one document): sustained `Store "<docId>".` log lines every ~1.3–2.2s for minutes despite `maxDebounce: 10000`, with the matching CPU / database / Redis-lock churn. Any store-duration spike (S3 latency, database contention, a blocked event loop) bootstraps it.

The regression was introduced by #1014 (`708bfdb0`, shipped in v3.4.0) and is still present in v4.1.1 and `main`.

#1024 looks like another report of the same downstream symptoms (CPU + Redis command spike that only a restart clears).

## Root cause

`useDebounce()`'s `run()` awaits the in-flight execution **before** deleting the timer entry:

```ts
const run = async () => {
    if (runningExecutions.has(id)) {
        // wait for previous execution to finish
        await runningExecutions.get(id);   // <-- run() suspends here...
    }
    timers.delete(id);                     // <-- ...while the entry stays in the map
    ...
};
```

While `run()` is suspended, the stale entry — which keeps its original `start` (that's how `maxDebounce` tracking works) — stays in the `timers` map. Once that entry is ≥ `maxDebounce` old, **every** subsequent `debounce()` call takes this branch:

```ts
if (Date.now() - start >= maxDebounce) {
  return run(); // fires immediately, once per incoming update
}
```

Each of those `run()`s awaits the same in-flight execution; when it resolves they all proceed and call `func()`, serialised only by `document.saveMutex` — so the queued stores execute back-to-back. While that queue drains, freshly created timer entries also cross the `maxDebounce` age (a store is always in flight), so under continuous editing new runs are queued at least as fast as they drain.

Before #1014, `run()` deleted the timer entry synchronously before calling `func()`, so this queueing was impossible (worst case was two briefly overlapping stores — the issue #997/#1014 set out to fix).

## Steps to reproduce

There's a test in this PR, or I have a self-contained [reproduction gist](https://gist.github.com/patrick-atticus/587aa39bf725301afa4d3ca88d95284a) (in-process server + 8 provider clients, ~2.5 minutes):

```bash
git clone https://gist.github.com/patrick-atticus/587aa39bf725301afa4d3ca88d95284a
cd 587aa39bf725301afa4d3ca88d95284a
npm install
npm run repro   # observe for ~1min
```

The script starts a `Server` (`debounce: 2000`, `maxDebounce: 10000`) whose `onStoreDocument` takes 300ms, except for store #3 which takes 12s (the "latency spike"). 8 `HocuspocusProvider` clients type continuously for 2 minutes.

Observed output on v4.1.1 (abridged):

```
[10.0s] store #1
[20.1s] store #2
[30.1s] store #3 (simulated 12s latency spike)
[42.1s] store #4
[42.4s] store #5
[42.7s] store #6
... (every ~0.3s, sustained while typing continues)
---
stores executed: 115 (healthy with maxDebounce=10000ms: ~13)
median gap between stores: 0.301s (healthy: ~10s)
=> STORE STORM REPRODUCED
```

With the one-line fix below applied to `dist/hocuspocus-server.cjs`, the identical run executes ~13 stores with a ~10s median gap.

## Expected behaviour

One slow store should result in at most one queued follow-up store (coalescing the updates that arrived while it was in flight). `onStoreDocument` should continue to fire at most once per `maxDebounce` per document under continuous editing.

## Proposed fix

Delete the timer entry synchronously, before any `await`, in `run()`.

With this change the maxDebounce-age branch can no longer re-fire for an entry whose `run()` is already pending, and a store that arrives while one is in flight degrades to exactly one coalesced follow-up store. We verified this fix in two ways:

- isolated simulation of both debouncer versions (continuous updates, one 12s store): unfixed v3/v4 executes 26 stores in 90s with up to 18 concurrent `func()` calls; fixed version executes 9 (one per `maxDebounce`) with max concurrency 1 — identical to v2.15.3's behaviour;
- full application load test (16 real provider clients against our app server): 148 stores in 190s unfixed vs 18 fixed.

## Environment

- **Hocuspocus version**: reproduced on 3.4.4 and 4.1.1 (regression introduced in 3.4.0 via #1014; v2.x and ≤3.3.x unaffected)
- **Node.js**: 22.x
- **OS**: macOS / Linux
