### PR TITLE
feat: enforce pre-auth resource limits to safeguard server stability

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -54,6 +54,33 @@ server.listen()
 
 For a database-backed server, combine with an extension like [`@hocuspocus/extension-sqlite`](../extension-sqlite) or [`@hocuspocus/extension-database`](../extension-database).
 
+## Resource limits
+
+Messages received from a client before authentication completes are buffered in
+memory. To prevent an unauthenticated client from exhausting server memory, the
+server bounds this buffer per connection and closes connections that exceed the
+limits. The defaults are safe for typical clients (which authenticate before
+sending document data); raise them only if you have a specific need.
+
+```js
+const server = new Server({
+  port: 1234,
+
+  // Max bytes buffered across all documents of one unauthenticated connection.
+  maxUnauthenticatedQueueSize: 5 * 1024 * 1024, // default: 5 MiB
+
+  // Max number of messages buffered for one unauthenticated connection.
+  maxUnauthenticatedQueueMessages: 1_000, // default: 1000
+
+  // Max number of documents one connection may open before authenticating any.
+  maxPendingDocuments: 100, // default: 100
+
+  // Connections that don't authenticate any document within `timeout` ms are
+  // closed. This deadline is not refreshed by inbound traffic.
+  timeout: 60_000, // default: 60s
+})
+```
+
 ## Non-Node.js runtimes
 
 Use the `Hocuspocus` class directly to attach to any `WebSocketLike` instance (Bun, Deno, Cloudflare Workers, Express, etc.):

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -84,6 +84,12 @@ export class ClientConnection<Context = any> {
 	// deadline that inbound traffic cannot refresh.
 	private readonly connectionEstablishedAt = Date.now();
 
+	// Set once any document on this connection has successfully authenticated.
+	// Sticky on purpose: once a client has proven itself, the normal idle-timeout
+	// logic applies for the rest of the socket's life, even if it later closes all
+	// of its documents.
+	private hasAuthenticated = false;
+
 	/**
 	 * The `ClientConnection` class receives incoming WebSocket connections,
 	 * runs all hooks:
@@ -172,13 +178,14 @@ export class ClientConnection<Context = any> {
 	 * Awareness updates (~every 30s) keep active connections alive.
 	 */
 	private check = () => {
-		// Until at least one document on this connection is authenticated, use an
+		// Until the connection has authenticated at least one document, use an
 		// absolute deadline based on when the connection opened. Inbound traffic
 		// updates `lastMessageReceivedAt`, so a flood of unauthenticated frames
 		// could otherwise refresh the timeout forever and keep the socket alive.
-		const hasEstablishedConnection =
-			Object.keys(this.documentConnections).length > 0;
-		const referenceTime = hasEstablishedConnection
+		// Once authenticated, fall back to the normal idle behavior — even if the
+		// client later closes all of its documents — so an established client that
+		// keeps its socket open is not closed based on the original open time.
+		const referenceTime = this.hasAuthenticated
 			? this.lastMessageReceivedAt
 			: this.connectionEstablishedAt;
 
@@ -207,14 +214,17 @@ export class ClientConnection<Context = any> {
 		return total;
 	}
 
-	// Number of distinct documents that have buffered data but have not yet
-	// sent an authentication message. Each such document holds its own queue and
-	// hook payload, so this is capped to prevent a single connection from
-	// amplifying memory usage by fanning out across many document names.
+	// Number of distinct documents on this connection that have not yet finished
+	// authenticating. Each holds its own queue and hook payload, so this is capped
+	// to prevent a single connection from amplifying memory usage by fanning out
+	// across many document names. We count by `isAuthenticated` (not by whether an
+	// Auth frame has been seen) so that sending an Auth frame first — which marks
+	// the document as "establishing" but keeps its hook payload alive while a slow
+	// `onAuthenticate` runs — cannot be used to bypass the limit.
 	private getPendingDocumentCount(): number {
 		let total = 0;
-		for (const rawKey of Object.keys(this.incomingMessageQueue)) {
-			if (!this.documentConnectionsEstablished.has(rawKey)) {
+		for (const rawKey of Object.keys(this.hookPayloads)) {
+			if (!this.hookPayloads[rawKey].connectionConfig.isAuthenticated) {
 				total += 1;
 			}
 		}
@@ -503,6 +513,7 @@ export class ClientConnection<Context = any> {
 				);
 				// All `onAuthenticate` hooks passed.
 				hookPayload.connectionConfig.isAuthenticated = true;
+				this.hasAuthenticated = true;
 
 				// Let the client know that authentication was successful.
 				const message = new OutgoingMessage(responseAddress).writeAuthenticated(

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -39,6 +39,10 @@ export class ClientConnection<Context = any> {
 	// be queued and handled later.
 	private readonly incomingMessageQueue: Record<string, Uint8Array[]> = {};
 
+	// Tracks the number of bytes buffered per document key, so the total amount
+	// of unauthenticated buffered data can be bounded (see GHSA-xwhh-v746-pj9m).
+	private readonly incomingMessageQueueBytes: Record<string, number> = {};
+
 	// While the connection is establishing, keep track of which documents have received auth
 	private readonly documentConnectionsEstablished = new Set<string>();
 
@@ -66,9 +70,19 @@ export class ClientConnection<Context = any> {
 
 	timeout: number;
 
+	private readonly maxUnauthenticatedQueueSize: number;
+
+	private readonly maxUnauthenticatedQueueMessages: number;
+
+	private readonly maxPendingDocuments: number;
+
 	pingInterval: NodeJS.Timeout;
 
 	lastMessageReceivedAt = Date.now();
+
+	// When the connection was opened. Used to enforce a pre-authentication
+	// deadline that inbound traffic cannot refresh.
+	private readonly connectionEstablishedAt = Date.now();
 
 	/**
 	 * The `ClientConnection` class receives incoming WebSocket connections,
@@ -90,10 +104,18 @@ export class ClientConnection<Context = any> {
 		private readonly hooks: Hocuspocus["hooks"],
 		private readonly opts: {
 			timeout: number;
+			maxUnauthenticatedQueueSize?: number;
+			maxUnauthenticatedQueueMessages?: number;
+			maxPendingDocuments?: number;
 		},
 		private readonly defaultContext: Context = {} as Context,
 	) {
 		this.timeout = opts.timeout;
+		this.maxUnauthenticatedQueueSize =
+			opts.maxUnauthenticatedQueueSize ?? 5 * 1024 * 1024;
+		this.maxUnauthenticatedQueueMessages =
+			opts.maxUnauthenticatedQueueMessages ?? 1_000;
+		this.maxPendingDocuments = opts.maxPendingDocuments ?? 100;
 		this.pingInterval = setInterval(this.check, this.timeout);
 	}
 
@@ -110,6 +132,37 @@ export class ClientConnection<Context = any> {
 		Object.values(this.documentConnections).forEach((connection) =>
 			connection.close(event),
 		);
+
+		// Release any buffered pre-authentication state. Without this, a
+		// timed-out or rejected connection would keep its queued messages and
+		// hook payloads in memory until the process exits (GHSA-xwhh-v746-pj9m).
+		for (const rawKey of Object.keys(this.incomingMessageQueue)) {
+			delete this.incomingMessageQueue[rawKey];
+			delete this.incomingMessageQueueBytes[rawKey];
+		}
+		for (const rawKey of Object.keys(this.hookPayloads)) {
+			delete this.hookPayloads[rawKey];
+		}
+		this.documentConnectionsEstablished.clear();
+	}
+
+	/**
+	 * Tear down the connection: release the established document connections and
+	 * the buffered pre-authentication state, then close the underlying socket.
+	 * Closing the socket is essential — otherwise an unauthenticated client can
+	 * keep the socket (and its resources) open even after a timeout fires.
+	 */
+	private terminate(event?: CloseEvent) {
+		this.close(event);
+
+		if (
+			this.websocket.readyState !== WsReadyStates.Closing &&
+			this.websocket.readyState !== WsReadyStates.Closed
+		) {
+			this.websocket.close(event?.code, event?.reason);
+		}
+
+		clearInterval(this.pingInterval);
 	}
 
 	/**
@@ -119,10 +172,54 @@ export class ClientConnection<Context = any> {
 	 * Awareness updates (~every 30s) keep active connections alive.
 	 */
 	private check = () => {
-		if (Date.now() - this.lastMessageReceivedAt > this.timeout) {
-			this.close(ConnectionTimeout);
+		// Until at least one document on this connection is authenticated, use an
+		// absolute deadline based on when the connection opened. Inbound traffic
+		// updates `lastMessageReceivedAt`, so a flood of unauthenticated frames
+		// could otherwise refresh the timeout forever and keep the socket alive.
+		const hasEstablishedConnection =
+			Object.keys(this.documentConnections).length > 0;
+		const referenceTime = hasEstablishedConnection
+			? this.lastMessageReceivedAt
+			: this.connectionEstablishedAt;
+
+		if (Date.now() - referenceTime > this.timeout) {
+			this.terminate(ConnectionTimeout);
 		}
 	};
+
+	// Total bytes currently buffered for unauthenticated documents on this
+	// connection. Derived on demand so the various cleanup paths only need to
+	// delete their keys without keeping a running counter in sync.
+	private getQueuedBytes(): number {
+		let total = 0;
+		for (const rawKey of Object.keys(this.incomingMessageQueueBytes)) {
+			total += this.incomingMessageQueueBytes[rawKey];
+		}
+		return total;
+	}
+
+	// Total number of messages currently buffered for unauthenticated documents.
+	private getQueuedMessageCount(): number {
+		let total = 0;
+		for (const rawKey of Object.keys(this.incomingMessageQueue)) {
+			total += this.incomingMessageQueue[rawKey].length;
+		}
+		return total;
+	}
+
+	// Number of distinct documents that have buffered data but have not yet
+	// sent an authentication message. Each such document holds its own queue and
+	// hook payload, so this is capped to prevent a single connection from
+	// amplifying memory usage by fanning out across many document names.
+	private getPendingDocumentCount(): number {
+		let total = 0;
+		for (const rawKey of Object.keys(this.incomingMessageQueue)) {
+			if (!this.documentConnectionsEstablished.has(rawKey)) {
+				total += 1;
+			}
+		}
+		return total;
+	}
 
 	/**
 	 * Set a callback that will be triggered when the connection is closed
@@ -262,6 +359,7 @@ export class ClientConnection<Context = any> {
 			delete this.hookPayloads[rawKey];
 			delete this.documentConnections[rawKey];
 			delete this.incomingMessageQueue[rawKey];
+			delete this.incomingMessageQueueBytes[rawKey];
 			this.documentConnectionsEstablished.delete(rawKey);
 		});
 
@@ -302,10 +400,15 @@ export class ClientConnection<Context = any> {
 			return;
 		}
 
-		// Drain queued messages to the Connection.
+		// Drain queued messages to the Connection. Once drained, the buffered
+		// data is no longer needed (subsequent messages route straight to the
+		// Connection), so release it and stop counting it against the queue
+		// limits.
 		this.incomingMessageQueue[rawKey]?.forEach((input) => {
 			connection.handleMessage(input);
 		});
+		delete this.incomingMessageQueue[rawKey];
+		delete this.incomingMessageQueueBytes[rawKey];
 
 		await this.hooks("connected", {
 			...hookPayload,
@@ -329,7 +432,22 @@ export class ClientConnection<Context = any> {
 					!this.documentConnectionsEstablished.has(rawKey)
 				)
 			) {
+				// Bound the amount of data buffered before authentication. An
+				// unauthenticated client must not be able to grow this queue without
+				// limit (GHSA-xwhh-v746-pj9m).
+				if (
+					this.getQueuedBytes() + data.byteLength >
+						this.maxUnauthenticatedQueueSize ||
+					this.getQueuedMessageCount() + 1 >
+						this.maxUnauthenticatedQueueMessages
+				) {
+					this.terminate(ResetConnection);
+					return;
+				}
+
 				this.incomingMessageQueue[rawKey].push(data);
+				this.incomingMessageQueueBytes[rawKey] =
+					(this.incomingMessageQueueBytes[rawKey] ?? 0) + data.byteLength;
 				return;
 			}
 
@@ -408,6 +526,7 @@ export class ClientConnection<Context = any> {
 				this.documentConnectionsEstablished.delete(rawKey);
 				delete this.hookPayloads[rawKey];
 				delete this.incomingMessageQueue[rawKey];
+				delete this.incomingMessageQueueBytes[rawKey];
 			}
 
 			// Catch errors due to failed decoding of data
@@ -444,6 +563,15 @@ export class ClientConnection<Context = any> {
 
 			const isFirst = this.incomingMessageQueue[rawKey] === undefined;
 			if (isFirst) {
+				// Cap the number of documents a single connection can open before
+				// authenticating any of them. Each pending document allocates its own
+				// queue and hook payload, so this prevents memory amplification by
+				// fanning out across many document names (GHSA-xwhh-v746-pj9m).
+				if (this.getPendingDocumentCount() >= this.maxPendingDocuments) {
+					this.terminate(ResetConnection);
+					return;
+				}
+
 				this.incomingMessageQueue[rawKey] = [];
 				if (this.hookPayloads[rawKey]) {
 					throw new Error("first message, but hookPayloads exists");

--- a/packages/server/src/ClientConnection.ts
+++ b/packages/server/src/ClientConnection.ts
@@ -90,6 +90,11 @@ export class ClientConnection<Context = any> {
 	// of its documents.
 	private hasAuthenticated = false;
 
+	// Set once the connection has been proactively torn down (timeout or a limit
+	// breach). Guards against processing — and re-logging — frames that were
+	// already in flight when we decided to close the socket.
+	private terminated = false;
+
 	/**
 	 * The `ClientConnection` class receives incoming WebSocket connections,
 	 * runs all hooks:
@@ -159,6 +164,11 @@ export class ClientConnection<Context = any> {
 	 * keep the socket (and its resources) open even after a timeout fires.
 	 */
 	private terminate(event?: CloseEvent) {
+		if (this.terminated) {
+			return;
+		}
+		this.terminated = true;
+
 		this.close(event);
 
 		if (
@@ -445,12 +455,19 @@ export class ClientConnection<Context = any> {
 				// Bound the amount of data buffered before authentication. An
 				// unauthenticated client must not be able to grow this queue without
 				// limit (GHSA-xwhh-v746-pj9m).
-				if (
-					this.getQueuedBytes() + data.byteLength >
-						this.maxUnauthenticatedQueueSize ||
-					this.getQueuedMessageCount() + 1 >
-						this.maxUnauthenticatedQueueMessages
-				) {
+				const queuedBytes = this.getQueuedBytes();
+				const queuedMessages = this.getQueuedMessageCount();
+				const exceedsBytes =
+					queuedBytes + data.byteLength > this.maxUnauthenticatedQueueSize;
+				const exceedsMessages =
+					queuedMessages + 1 > this.maxUnauthenticatedQueueMessages;
+
+				if (exceedsBytes || exceedsMessages) {
+					console.warn(
+						exceedsBytes
+							? `Hocuspocus: closing connection ${this.socketId}: unauthenticated message queue size limit exceeded for "${documentName}" (${queuedBytes + data.byteLength} > maxUnauthenticatedQueueSize ${this.maxUnauthenticatedQueueSize} bytes).`
+							: `Hocuspocus: closing connection ${this.socketId}: unauthenticated message queue length limit exceeded for "${documentName}" (${queuedMessages + 1} > maxUnauthenticatedQueueMessages ${this.maxUnauthenticatedQueueMessages}).`,
+					);
 					this.terminate(ResetConnection);
 					return;
 				}
@@ -552,6 +569,12 @@ export class ClientConnection<Context = any> {
 	 * when the WebSocket receives a binary message.
 	 */
 	handleMessage = (data: Uint8Array) => {
+		// Ignore anything that arrives after we've decided to tear the connection
+		// down (e.g. frames that were already in flight when a limit was breached).
+		if (this.terminated) {
+			return;
+		}
+
 		this.lastMessageReceivedAt = Date.now();
 
 		try {
@@ -579,6 +602,9 @@ export class ClientConnection<Context = any> {
 				// queue and hook payload, so this prevents memory amplification by
 				// fanning out across many document names (GHSA-xwhh-v746-pj9m).
 				if (this.getPendingDocumentCount() >= this.maxPendingDocuments) {
+					console.warn(
+						`Hocuspocus: closing connection ${this.socketId}: too many pending unauthenticated documents (maxPendingDocuments ${this.maxPendingDocuments}). Last requested document: "${documentName}".`,
+					);
 					this.terminate(ResetConnection);
 					return;
 				}

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -34,6 +34,9 @@ export const defaultConfiguration = {
 		gcFilter: () => true,
 	},
 	unloadImmediately: true,
+	maxUnauthenticatedQueueSize: 5 * 1024 * 1024,
+	maxUnauthenticatedQueueMessages: 1_000,
+	maxPendingDocuments: 100,
 };
 
 export class Hocuspocus<Context = any> {
@@ -221,6 +224,11 @@ export class Hocuspocus<Context = any> {
 			this.hooks.bind(this),
 			{
 				timeout: this.configuration.timeout,
+				maxUnauthenticatedQueueSize:
+					this.configuration.maxUnauthenticatedQueueSize,
+				maxUnauthenticatedQueueMessages:
+					this.configuration.maxUnauthenticatedQueueMessages,
+				maxPendingDocuments: this.configuration.maxPendingDocuments,
 			},
 			defaultContext,
 		);

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -226,6 +226,34 @@ export interface Configuration<Context = any> extends Extension<Context> {
 	unloadImmediately: boolean;
 
 	/**
+	 * Maximum number of bytes that may be buffered, across all documents, for a single
+	 * connection while it is still unauthenticated. Messages received before authentication
+	 * completes are queued in memory; without a limit an unauthenticated client could exhaust
+	 * server memory (see GHSA-xwhh-v746-pj9m). When the limit is exceeded the connection is closed.
+	 *
+	 * @default 5_242_880 (5 MiB)
+	 */
+	maxUnauthenticatedQueueSize: number;
+	/**
+	 * Maximum number of messages that may be buffered, across all documents, for a single
+	 * connection while it is still unauthenticated. When the limit is exceeded the connection
+	 * is closed.
+	 *
+	 * @default 1_000
+	 */
+	maxUnauthenticatedQueueMessages: number;
+	/**
+	 * Maximum number of distinct documents a single connection may open before any of them is
+	 * authenticated. Each pending document holds its own queue and hook payload, so an
+	 * unauthenticated client fanning out across many document names could otherwise exhaust
+	 * memory even while staying under the per-connection queue limits. When the limit is
+	 * exceeded the connection is closed.
+	 *
+	 * @default 100
+	 */
+	maxPendingDocuments: number;
+
+	/**
 	 * options to pass to the ydoc document
 	 */
 	yDocOptions: {

--- a/tests/server/unauthenticatedQueueLimit.ts
+++ b/tests/server/unauthenticatedQueueLimit.ts
@@ -1,0 +1,159 @@
+import test from 'ava'
+import * as encoding from 'lib0/encoding'
+import { writeAuthentication } from '@hocuspocus/common'
+import { newHocuspocus } from '../utils/index.ts'
+
+// Wire-level MessageType values (mirrors packages/server/src/types.ts).
+const MessageType = {
+  Auth: 2,
+  Stateless: 5,
+}
+
+const buildStatelessFrame = (documentName: string, payloadSize: number): Uint8Array => {
+  const encoder = encoding.createEncoder()
+  encoding.writeVarString(encoder, documentName)
+  encoding.writeVarUint(encoder, MessageType.Stateless)
+  encoding.writeVarString(encoder, 'A'.repeat(payloadSize))
+  return encoding.toUint8Array(encoder)
+}
+
+const buildAuthFrame = (documentName: string, token: string): Uint8Array => {
+  const encoder = encoding.createEncoder()
+  encoding.writeVarString(encoder, documentName)
+  encoding.writeVarUint(encoder, MessageType.Auth)
+  writeAuthentication(encoder, token)
+  return encoding.toUint8Array(encoder)
+}
+
+const openRawSocket = (url: string): Promise<WebSocket> => new Promise((resolve, reject) => {
+  const ws = new WebSocket(url)
+  ws.binaryType = 'arraybuffer'
+  ws.addEventListener('open', () => resolve(ws), { once: true })
+  ws.addEventListener('error', (event) => reject(event), { once: true })
+})
+
+// Wait for the server to close the socket, returning the close code.
+const waitForClose = (ws: WebSocket, timeoutMs = 5000): Promise<number> => new Promise((resolve, reject) => {
+  const timer = setTimeout(() => reject(new Error('connection was not closed by the server')), timeoutMs)
+  ws.addEventListener('close', (event) => {
+    clearTimeout(timer)
+    resolve(event.code)
+  }, { once: true })
+})
+
+test('closes an unauthenticated connection that exceeds the pre-auth message-count limit', async t => {
+  const server = await newHocuspocus(t, {
+    maxUnauthenticatedQueueMessages: 5,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  const closed = waitForClose(attacker)
+
+  // Flood many small non-Auth frames before authenticating. The server must
+  // stop queuing and close the connection once the count limit is exceeded.
+  for (let i = 0; i < 50; i += 1) {
+    attacker.send(buildStatelessFrame('queue-count-doc', 16))
+  }
+
+  const code = await closed
+  t.is(code, 4205, 'connection should be closed with ResetConnection (4205)')
+})
+
+test('closes an unauthenticated connection that exceeds the pre-auth byte limit', async t => {
+  const server = await newHocuspocus(t, {
+    // 256 KB total budget across the unauthenticated queue.
+    maxUnauthenticatedQueueSize: 256 * 1024,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  const closed = waitForClose(attacker)
+
+  // Each frame carries ~64 KB; the 5th frame crosses the 256 KB budget.
+  for (let i = 0; i < 20; i += 1) {
+    attacker.send(buildStatelessFrame('queue-bytes-doc', 64 * 1024))
+  }
+
+  const code = await closed
+  t.is(code, 4205, 'connection should be closed with ResetConnection (4205)')
+})
+
+test('closes an unauthenticated connection that opens too many pending documents', async t => {
+  const server = await newHocuspocus(t, {
+    maxPendingDocuments: 3,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  const closed = waitForClose(attacker)
+
+  // Spread a single small frame across many distinct document keys. A per-key
+  // limit alone would not catch this amplification; a per-connection cap does.
+  for (let i = 0; i < 25; i += 1) {
+    attacker.send(buildStatelessFrame(`pending-doc-${i}`, 16))
+  }
+
+  const code = await closed
+  t.is(code, 4205, 'connection should be closed with ResetConnection (4205)')
+})
+
+test('closes a continuously-sending unauthenticated connection once the pre-auth timeout elapses', async t => {
+  const server = await newHocuspocus(t, {
+    timeout: 1000,
+    // Keep queue limits high so the timeout — not the queue cap — is what fires.
+    maxUnauthenticatedQueueMessages: 1_000_000,
+    maxUnauthenticatedQueueSize: 1024 * 1024 * 1024,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+
+  const closed = waitForClose(attacker, 6000)
+
+  // Keep refreshing activity with tiny frames. The pre-auth deadline must not
+  // be reset by inbound traffic, so the connection still closes.
+  const interval = setInterval(() => {
+    if (attacker.readyState === WebSocket.OPEN) {
+      attacker.send(buildStatelessFrame('timeout-doc', 8))
+    }
+  }, 200)
+  t.teardown(() => {
+    clearInterval(interval)
+    attacker.close()
+  })
+
+  const code = await closed
+  clearInterval(interval)
+  t.is(code, 4408, 'connection should be closed with ConnectionTimeout (4408)')
+})
+
+test('does not close an authenticated connection that later exceeds the pre-auth limits', async t => {
+  const server = await newHocuspocus(t, {
+    maxUnauthenticatedQueueMessages: 5,
+    maxUnauthenticatedQueueSize: 64 * 1024,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  // Authenticate first (no onAuthenticate hook => allowed).
+  const authenticated = new Promise<void>((resolve) => {
+    attacker.addEventListener('message', () => resolve(), { once: true })
+  })
+  attacker.send(buildAuthFrame('authenticated-doc', ''))
+  await authenticated
+
+  // After auth, large/many frames flow through the established connection and
+  // are not subject to the pre-auth queue caps.
+  let closedEarly = false
+  attacker.addEventListener('close', () => { closedEarly = true }, { once: true })
+  for (let i = 0; i < 50; i += 1) {
+    attacker.send(buildStatelessFrame('authenticated-doc', 64 * 1024))
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  t.false(closedEarly, 'authenticated connection must not be closed by pre-auth queue limits')
+})

--- a/tests/server/unauthenticatedQueueLimit.ts
+++ b/tests/server/unauthenticatedQueueLimit.ts
@@ -25,6 +25,13 @@ const buildAuthFrame = (documentName: string, token: string): Uint8Array => {
   return encoding.toUint8Array(encoder)
 }
 
+const buildCloseFrame = (documentName: string): Uint8Array => {
+  const encoder = encoding.createEncoder()
+  encoding.writeVarString(encoder, documentName)
+  encoding.writeVarUint(encoder, 7) // MessageType.CLOSE
+  return encoding.toUint8Array(encoder)
+}
+
 const openRawSocket = (url: string): Promise<WebSocket> => new Promise((resolve, reject) => {
   const ws = new WebSocket(url)
   ws.binaryType = 'arraybuffer'
@@ -128,6 +135,67 @@ test('closes a continuously-sending unauthenticated connection once the pre-auth
   const code = await closed
   clearInterval(interval)
   t.is(code, 4408, 'connection should be closed with ConnectionTimeout (4408)')
+})
+
+test('counts in-flight authentications toward the pending-document limit', async t => {
+  const server = await newHocuspocus(t, {
+    maxPendingDocuments: 3,
+    // Never resolves, so every document stays in the "authenticating" state.
+    // Sending Auth first marks a document as establishing but keeps its hook
+    // payload alive while onAuthenticate runs — this must still count.
+    onAuthenticate: () => new Promise(() => {}),
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  const closed = waitForClose(attacker)
+
+  // Send Auth as the FIRST frame for many distinct documents.
+  for (let i = 0; i < 25; i += 1) {
+    attacker.send(buildAuthFrame(`auth-first-doc-${i}`, ''))
+  }
+
+  const code = await closed
+  t.is(code, 4205, 'connection should be closed with ResetConnection (4205)')
+})
+
+test('does not close an authenticated connection that has closed all of its documents', async t => {
+  const server = await newHocuspocus(t, {
+    timeout: 600,
+  })
+
+  const attacker = await openRawSocket(server.server!.webSocketURL)
+  t.teardown(() => attacker.close())
+
+  // Authenticate a document (no onAuthenticate hook => allowed).
+  const authenticated = new Promise<void>((resolve) => {
+    attacker.addEventListener('message', () => resolve(), { once: true })
+  })
+  attacker.send(buildAuthFrame('soon-empty-doc', ''))
+  await authenticated
+
+  let closedCode: number | undefined
+  attacker.addEventListener('close', (event) => { closedCode = event.code }, { once: true })
+
+  // Keep the socket alive with periodic frames so `lastMessageReceivedAt` stays
+  // fresh. Halfway through, close the only document, leaving zero established
+  // document connections. Because the connection already authenticated, the idle
+  // check must keep using `lastMessageReceivedAt` rather than the original open
+  // time — so the socket must survive past `timeout` measured from open.
+  const interval = setInterval(() => {
+    if (attacker.readyState === WebSocket.OPEN) {
+      attacker.send(buildStatelessFrame('keepalive-doc', 8))
+    }
+  }, 150)
+  t.teardown(() => clearInterval(interval))
+
+  await new Promise((resolve) => setTimeout(resolve, 700))
+  attacker.send(buildCloseFrame('soon-empty-doc'))
+  await new Promise((resolve) => setTimeout(resolve, 1100))
+
+  clearInterval(interval)
+  t.is(closedCode, undefined, 'authenticated connection must not be closed by the pre-auth deadline')
 })
 
 test('does not close an authenticated connection that later exceeds the pre-auth limits', async t => {


### PR DESCRIPTION
Adds limits to safeguard server stability. Before this PR, it is possible for a single connection to fill up all server memory by sending messages before authenticating.