### PR TITLE
Make sure server.destroy() only runs once

### DIFF
--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -197,7 +197,18 @@ export class Server<Context = any> {
 		}) as AddressInfo;
 	}
 
+	private destroyPromise?: Promise<void>;
+
 	async destroy(): Promise<void> {
+		// Guard against multiple shutdowns (e.g. repeated SIGINT signals).
+		// Subsequent callers await the same in-flight shutdown rather than
+		// re-running close hooks on already-closed resources.
+		this.destroyPromise ??= this.runDestroy();
+
+		return this.destroyPromise;
+	}
+
+	private async runDestroy(): Promise<void> {
 		await new Promise<void>((resolve) => {
 			this.httpServer.close();
 

--- a/tests/server/destroy.ts
+++ b/tests/server/destroy.ts
@@ -1,0 +1,27 @@
+import test from "ava";
+import { Server } from "@hocuspocus/server";
+
+test("destroy only runs once when called multiple times", async (t) => {
+	let destroyed = 0;
+
+	const server = new Server({
+		port: 0,
+		quiet: true,
+		stopOnSignals: false,
+		async onDestroy() {
+			destroyed += 1;
+		},
+	});
+
+	t.teardown(() => server.httpServer.close());
+
+	await server.listen();
+
+	// Concurrent and subsequent calls (e.g. from repeated SIGINT signals)
+	// must not re-run the shutdown, which would close already-closed
+	// resources in extensions.
+	await Promise.all([server.destroy(), server.destroy()]);
+	await server.destroy();
+
+	t.is(destroyed, 1);
+});


### PR DESCRIPTION
Multiple calls to destroy() would trigger onDestroy hooks multiple times.
This is unexpected for extensions, and created some strange behaviours and errors
(for example in the redis-extension, which tried to close the same connection multiple times)

destroy can get called multiple times when multiple SIGINT signals get sent
while a slower onDestroy hook is still processing.
