### PR TITLE
feat: add consistent state synchronization across Redis instances

### DIFF
--- a/packages/extension-redis/README.md
+++ b/packages/extension-redis/README.md
@@ -47,6 +47,26 @@ new Redis({
 
 Redis handles real-time sync — you still need a persistence extension (e.g. [`@hocuspocus/extension-sqlite`](../extension-sqlite), [`@hocuspocus/extension-s3`](../extension-s3), or your own [`Database`](../extension-database)) to store documents long-term.
 
+### Consistent reads on load
+
+When a document is loaded on one instance while another instance already has it
+open (and possibly modified in memory, not yet persisted), the load blocks until
+the other instance has sent its current state — so a `DirectConnection` or a
+freshly connected client observes the latest collaborative content rather than
+just what was read from storage. If no other instance has the document open, the
+load is not delayed.
+
+The wait is bounded by `awaitInitialSyncTimeout` (ms, default `1000`). Set it to
+`0` to disable the wait and restore the previous fire-and-forget behavior:
+
+```js
+new Redis({
+  host: "127.0.0.1",
+  port: 6379,
+  awaitInitialSyncTimeout: 1000,
+})
+```
+
 ## Documentation
 
 Full scaling architecture and multi-instance deployment guide: [tiptap.dev/docs/hocuspocus/server/extensions/redis](https://tiptap.dev/docs/hocuspocus/server/extensions/redis).

--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -247,20 +247,31 @@ export class Redis implements Extension {
 		// dropped while we wait for it.
 		this.documents.set(documentName, document);
 
-		await new Promise<void>((resolve, reject) => {
-			// On document creation the node will connect to pub and sub channels
-			// for the document.
-			this.sub.subscribe(this.subKey(documentName), (error: any) => {
-				if (error) {
-					reject(error);
-					return;
-				}
+		try {
+			await new Promise<void>((resolve, reject) => {
+				// On document creation the node will connect to pub and sub channels
+				// for the document.
+				this.sub.subscribe(this.subKey(documentName), (error: any) => {
+					if (error) {
+						reject(error);
+						return;
+					}
 
-				resolve();
+					resolve();
+				});
 			});
-		});
 
-		await this.syncInitialStateFromPeers(documentName, document);
+			await this.syncInitialStateFromPeers(documentName, document);
+		} catch (error) {
+			// Loading failed: stop tracking the document so future messages aren't
+			// applied to a doc that never finished loading, release any pending
+			// wait, and best-effort unsubscribe (afterUnloadDocument does not run
+			// for a load that never completed).
+			this.documents.delete(documentName);
+			this.pendingInitialSyncResolves.delete(documentName);
+			this.sub.unsubscribe(this.subKey(documentName), () => {});
+			throw error;
+		}
 	}
 
 	/**
@@ -274,30 +285,39 @@ export class Redis implements Extension {
 	) {
 		const timeout = this.configuration.awaitInitialSyncTimeout;
 
+		const waitForPeers =
+			timeout > 0 && (await this.hasOtherSubscribers(documentName));
+
+		// Announce our state and request awareness. Awaited so a Redis publish
+		// failure surfaces as a load error instead of an unhandled rejection.
+		await Promise.all([
+			this.publishFirstSyncStep(documentName, document),
+			this.requestAwarenessFromOtherInstances(documentName),
+		]);
+
 		// Skip the wait when it's disabled or nobody else has the document open:
 		// there is no peer to sync from, so blocking would only add latency.
-		if (timeout <= 0 || !(await this.hasOtherSubscribers(documentName))) {
-			this.publishFirstSyncStep(documentName, document);
-			this.requestAwarenessFromOtherInstances(documentName);
+		if (!waitForPeers) {
 			return;
 		}
 
+		// A peer has the document open. Block until it replies with its state
+		// (a SyncStep2/Update applied via handleIncomingMessage resolves this) or
+		// the timeout elapses. The reply cannot arrive before the SyncStep1 we
+		// just published is delivered, so registering the resolver now — right
+		// after the awaited publish, before yielding to the event loop — cannot
+		// miss it.
 		await new Promise<void>((resolve) => {
 			const timer = setTimeout(() => {
 				this.pendingInitialSyncResolves.delete(documentName);
 				resolve();
 			}, timeout);
 
-			// Register the resolver *before* publishing so a fast reply can't be
-			// missed.
 			this.pendingInitialSyncResolves.set(documentName, () => {
 				clearTimeout(timer);
 				this.pendingInitialSyncResolves.delete(documentName);
 				resolve();
 			});
-
-			this.publishFirstSyncStep(documentName, document);
-			this.requestAwarenessFromOtherInstances(documentName);
 		});
 	}
 

--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -19,8 +19,13 @@ import {
 	IncomingMessage,
 	isTransactionOrigin,
 	MessageReceiver,
+	MessageType,
 	OutgoingMessage,
 } from "@hocuspocus/server";
+import {
+	messageYjsSyncStep2,
+	messageYjsUpdate,
+} from "y-protocols/sync";
 import {
 	ExecutionError,
 	type ExecutionResult,
@@ -80,6 +85,24 @@ export interface Configuration {
 	 * sync messages to be received by the subscription before it's closed.
 	 */
 	disconnectDelay: number;
+	/**
+	 * The maximum time (in ms) `afterLoadDocument` waits for another instance to
+	 * send its state when loading a document that is already open elsewhere.
+	 *
+	 * When a document is loaded on this instance while another instance already
+	 * has it open (and possibly modified in memory, not yet persisted), we
+	 * publish a SyncStep1 and block the load until the peer replies with its
+	 * state (SyncStep2) — or this timeout elapses. This guarantees that callers
+	 * (most importantly a `DirectConnection`) observe the latest collaborative
+	 * state instead of just what was loaded from storage.
+	 *
+	 * If no other instance is subscribed to the document, the wait is skipped
+	 * entirely, so a cold/lone load is not delayed.
+	 *
+	 * Set to `0` to disable the wait and restore the legacy fire-and-forget
+	 * behavior.
+	 */
+	awaitInitialSyncTimeout: number;
 }
 
 export class Redis implements Extension {
@@ -97,6 +120,7 @@ export class Redis implements Extension {
 		identifier: `host-${crypto.randomUUID()}`,
 		lockTimeout: 1000,
 		disconnectDelay: 1000,
+		awaitInitialSyncTimeout: 1000,
 	};
 
 	redisTransactionOrigin: RedisTransactionOrigin = {
@@ -119,6 +143,24 @@ export class Redis implements Extension {
 		string,
 		{ timeout: NodeJS.Timeout; resolve: () => void }
 	>();
+
+	/**
+	 * Documents this instance has loaded and subscribed to, keyed by name.
+	 *
+	 * This mirrors `instance.documents` but is populated at the very start of
+	 * `afterLoadDocument` — i.e. *before* Hocuspocus registers the document in
+	 * `instance.documents` (which only happens once loading, including this
+	 * hook, has fully resolved). That early registration is what lets
+	 * `handleIncomingMessage` apply a peer's SyncStep2 reply while we are still
+	 * blocking the load on it.
+	 */
+	private documents = new Map<string, Document>();
+
+	/**
+	 * Resolvers for in-flight `afterLoadDocument` waits, keyed by document name.
+	 * Invoked by `handleIncomingMessage` as soon as a peer's state arrives.
+	 */
+	private pendingInitialSyncResolves = new Map<string, () => void>();
 
 	public constructor(configuration: Partial<Configuration>) {
 		this.configuration = {
@@ -198,21 +240,116 @@ export class Redis implements Extension {
 		documentName,
 		document,
 	}: afterLoadDocumentPayload) {
-		return new Promise((resolve, reject) => {
+		// Track the document locally right away so `handleIncomingMessage` can
+		// apply inbound messages to it even before Hocuspocus has finished
+		// loading it (it only lands in `instance.documents` after this hook
+		// resolves). Without this, the SyncStep2 reply we request below would be
+		// dropped while we wait for it.
+		this.documents.set(documentName, document);
+
+		await new Promise<void>((resolve, reject) => {
 			// On document creation the node will connect to pub and sub channels
 			// for the document.
-			this.sub.subscribe(this.subKey(documentName), async (error: any) => {
+			this.sub.subscribe(this.subKey(documentName), (error: any) => {
 				if (error) {
 					reject(error);
 					return;
 				}
 
-				this.publishFirstSyncStep(documentName, document);
-				this.requestAwarenessFromOtherInstances(documentName);
-
-				resolve(undefined);
+				resolve();
 			});
 		});
+
+		await this.syncInitialStateFromPeers(documentName, document);
+	}
+
+	/**
+	 * Announce our state to other instances and — when another instance already
+	 * has this document open — block until it has sent us its state (or the
+	 * configured timeout elapses). See {@link Configuration.awaitInitialSyncTimeout}.
+	 */
+	private async syncInitialStateFromPeers(
+		documentName: string,
+		document: Document,
+	) {
+		const timeout = this.configuration.awaitInitialSyncTimeout;
+
+		// Skip the wait when it's disabled or nobody else has the document open:
+		// there is no peer to sync from, so blocking would only add latency.
+		if (timeout <= 0 || !(await this.hasOtherSubscribers(documentName))) {
+			this.publishFirstSyncStep(documentName, document);
+			this.requestAwarenessFromOtherInstances(documentName);
+			return;
+		}
+
+		await new Promise<void>((resolve) => {
+			const timer = setTimeout(() => {
+				this.pendingInitialSyncResolves.delete(documentName);
+				resolve();
+			}, timeout);
+
+			// Register the resolver *before* publishing so a fast reply can't be
+			// missed.
+			this.pendingInitialSyncResolves.set(documentName, () => {
+				clearTimeout(timer);
+				this.pendingInitialSyncResolves.delete(documentName);
+				resolve();
+			});
+
+			this.publishFirstSyncStep(documentName, document);
+			this.requestAwarenessFromOtherInstances(documentName);
+		});
+	}
+
+	/**
+	 * Whether another instance is currently subscribed to a document's channel.
+	 * We are subscribed ourselves, so a subscriber count greater than one means
+	 * at least one peer has the document open.
+	 */
+	private async hasOtherSubscribers(documentName: string): Promise<boolean> {
+		try {
+			const result = (await this.pub.pubsub(
+				"NUMSUB",
+				this.subKey(documentName),
+			)) as [string, number | string];
+			return Number(result?.[1] ?? 0) > 1;
+		} catch {
+			// NUMSUB may be unavailable in some setups (e.g. certain clusters).
+			// Assume peers might exist so correctness is preserved; the timeout
+			// still bounds the wait.
+			return true;
+		}
+	}
+
+	/**
+	 * Resolve a pending `afterLoadDocument` wait once a peer's state has been
+	 * applied.
+	 */
+	private resolveInitialSync(documentName: string) {
+		this.pendingInitialSyncResolves.get(documentName)?.();
+	}
+
+	/**
+	 * Peek whether a message carries another instance's document state
+	 * (SyncStep2 or Update) without consuming the decoder. A SyncStep1 only
+	 * *requests* state, so it must not release an initial-sync wait.
+	 */
+	private messageCarriesPeerState(message: IncomingMessage): boolean {
+		const { pos } = message.decoder;
+		try {
+			const type = message.readVarUint();
+			if (type !== MessageType.Sync && type !== MessageType.SyncReply) {
+				return false;
+			}
+			const syncType = message.readVarUint();
+			return (
+				syncType === messageYjsSyncStep2 || syncType === messageYjsUpdate
+			);
+		} catch {
+			return false;
+		} finally {
+			message.decoder.pos = pos;
+		}
 	}
 
 	/**
@@ -373,11 +510,18 @@ export class Redis implements Extension {
 		const documentName = message.readVarString();
 		message.writeVarString(documentName);
 
-		const document = this.instance.documents.get(documentName);
+		// Prefer the extension-local map: it also contains documents that are
+		// still loading (not yet in `instance.documents`), which is exactly when
+		// a blocking `afterLoadDocument` needs to receive the peer's reply.
+		const document =
+			this.documents.get(documentName) ??
+			this.instance.documents.get(documentName);
 
 		if (!document) {
 			return;
 		}
+
+		const carriesPeerState = this.messageCarriesPeerState(message);
 
 		const receiver = new MessageReceiver(message, this.redisTransactionOrigin);
 		await receiver.apply(document, undefined, (reply) => {
@@ -386,6 +530,12 @@ export class Redis implements Extension {
 				this.encodeMessage(reply),
 			);
 		});
+
+		// A peer answered our SyncStep1 with its state — the document has now
+		// caught up, so any blocking initial-sync wait can be released.
+		if (carriesPeerState) {
+			this.resolveInitialSync(documentName);
+		}
 	};
 
 	/**
@@ -415,6 +565,9 @@ export class Redis implements Extension {
 
 	async afterUnloadDocument(data: afterUnloadDocumentPayload) {
 		if (data.instance.documents.has(data.documentName)) return; // skip unsubscribe if the document is already loaded again (maybe fast reconnect)
+
+		this.resolveInitialSync(data.documentName);
+		this.documents.delete(data.documentName);
 
 		this.sub.unsubscribe(this.subKey(data.documentName), (error: any) => {
 			if (error) {

--- a/tests/extension-redis/onStateless.ts
+++ b/tests/extension-redis/onStateless.ts
@@ -99,52 +99,90 @@ test("client stateless messages shouldnt propagate to other server", async (t) =
 });
 
 test("server client stateless messages shouldnt propagate to other client", async (t) => {
-	await new Promise(async (resolve) => {
-		const redisPrefix = crypto.randomUUID();
+	const redisPrefix = crypto.randomUUID();
+	const response = "test123";
+	const barrier = "redis-barrier";
+	const remotePayloads: string[] = [];
 
-		const server = await newHocuspocus(t, {
-			extensions: [
-				new Redis({
-					...redisConnectionSettings,
-					identifier: `server${crypto.randomUUID()}`,
-					prefix: redisPrefix,
-				}),
-			],
-			async onStateless({ connection, document }) {
-				connection.sendStateless("test123");
-			},
-		});
-
-		const anotherServer = await newHocuspocus(t, {
-			extensions: [
-				new Redis({
-					...redisConnectionSettings,
-					identifier: `anotherServer${crypto.randomUUID()}`,
-					prefix: redisPrefix,
-				}),
-			],
-			async onStateless() {
-				t.fail();
-			},
-		});
-
-		const provider2 = newHocuspocusProvider(t, anotherServer, {
-			onStateless() {
-				t.fail();
-			},
-		});
-
-		const provider = newHocuspocusProvider(t, server, {
-			onSynced() {
-				provider.sendStateless("ok");
-			},
-			onStateless() {
-				t.pass();
-			},
-		});
-
-		setTimeout(() => {
-			resolve("done");
-		}, 500);
+	let resolveResponse: () => void;
+	const responseReceived = new Promise<void>((resolve) => {
+		resolveResponse = resolve;
 	});
+	let resolveRemoteSynced: () => void;
+	const remoteSynced = new Promise<void>((resolve) => {
+		resolveRemoteSynced = resolve;
+	});
+	let resolveRemoteBarrier: () => void;
+	const remoteBarrierReceived = new Promise<void>((resolve) => {
+		resolveRemoteBarrier = resolve;
+	});
+	let resolveSenderSynced: () => void;
+	const senderSynced = new Promise<void>((resolve) => {
+		resolveSenderSynced = resolve;
+	});
+
+	const server = await newHocuspocus(t, {
+		extensions: [
+			new Redis({
+				...redisConnectionSettings,
+				identifier: `server${crypto.randomUUID()}`,
+				prefix: redisPrefix,
+			}),
+		],
+		async onStateless({ connection }) {
+			connection.sendStateless(response);
+		},
+	});
+
+	const anotherServer = await newHocuspocus(t, {
+		extensions: [
+			new Redis({
+				...redisConnectionSettings,
+				identifier: `anotherServer${crypto.randomUUID()}`,
+				prefix: redisPrefix,
+			}),
+		],
+		async onStateless() {
+			t.fail();
+		},
+	});
+
+	newHocuspocusProvider(t, anotherServer, {
+		onSynced() {
+			resolveRemoteSynced();
+		},
+		onStateless({ payload }) {
+			if (payload === barrier) {
+				resolveRemoteBarrier();
+				return;
+			}
+			remotePayloads.push(payload);
+		},
+	});
+
+	const provider = newHocuspocusProvider(t, server, {
+		onSynced() {
+			resolveSenderSynced();
+		},
+		onStateless({ payload }) {
+			if (payload === response) {
+				resolveResponse();
+			}
+		},
+	});
+
+	await Promise.all([remoteSynced, senderSynced]);
+	provider.sendStateless("ok");
+	await responseReceived;
+
+	const document = server.documents.get("hocuspocus-test");
+	if (!document) {
+		throw new Error("Expected the document to be loaded");
+	}
+	// Redis preserves publish order, so receiving this broadcast proves any
+	// accidental propagation of the earlier response has already arrived.
+	document.broadcastStateless(barrier);
+	await remoteBarrierReceived;
+
+	t.deepEqual(remotePayloads, []);
 });

--- a/tests/extension-redis/openDirectConnection.ts
+++ b/tests/extension-redis/openDirectConnection.ts
@@ -1,0 +1,74 @@
+import { Redis } from "@hocuspocus/extension-redis";
+import test from "ava";
+import { newHocuspocus, redisConnectionSettings, sleep } from "../utils/index.ts";
+
+const newRedisServer = (t: any, prefix: string, identifier: string, options = {}) =>
+	newHocuspocus(t, {
+		extensions: [
+			new Redis({
+				...redisConnectionSettings,
+				identifier: `${identifier}${crypto.randomUUID()}`,
+				prefix,
+				// Keep teardown quick — these delays are unrelated to load-time sync.
+				disconnectDelay: 100,
+				...options,
+			}),
+		],
+	});
+
+test("direct connection on a second instance sees edits that only live in another instance's memory", async (t) => {
+	const prefix = `extension-redis/openDirectConnection-${crypto.randomUUID()}`;
+
+	const serverA = await newRedisServer(t, prefix, "serverA");
+	const serverB = await newRedisServer(t, prefix, "serverB");
+
+	// Open + modify the document on server A and keep the connection open so the
+	// document stays in memory on A and is never persisted to storage. The only
+	// way server B can learn about this edit is via the Redis sync handshake.
+	const directA = await serverA.openDirectConnection("sync-on-open");
+	await directA.transact((doc) => {
+		doc.getMap("config").set("foo", "bar");
+	});
+
+	// Open a direct connection on server B and read immediately. Without an
+	// inbound-sync wait in afterLoadDocument, B only has the (empty) state it
+	// loaded from storage, so this read sees `undefined`.
+	const directB = await serverB.openDirectConnection("sync-on-open");
+
+	let seenValue: unknown;
+	await directB.transact((doc) => {
+		seenValue = doc.getMap("config").get("foo");
+	});
+
+	t.is(seenValue, "bar");
+
+	await directB.disconnect();
+	await directA.disconnect();
+});
+
+test("openDirectConnection on a single instance does not stall waiting for absent peers", async (t) => {
+	const prefix = `extension-redis/openDirectConnection-solo-${crypto.randomUUID()}`;
+
+	// A generous sync timeout: if presence detection is broken and we wait for
+	// peers that don't exist, this load would take ~5s instead of being instant.
+	const server = await newRedisServer(t, prefix, "solo", {
+		awaitInitialSyncTimeout: 5000,
+	});
+
+	const start = Date.now();
+	const direct = await server.openDirectConnection("solo-doc");
+	const elapsed = Date.now() - start;
+
+	t.true(
+		elapsed < 2000,
+		`openDirectConnection should not block on absent peers (took ${elapsed}ms)`,
+	);
+
+	await direct.transact((doc) => {
+		doc.getMap("config").set("foo", "bar");
+	});
+	t.is(direct.document?.getMap("config").get("foo"), "bar");
+
+	await direct.disconnect();
+	await sleep(50);
+});


### PR DESCRIPTION
feat: add consistent state synchronization across Redis instances with `awaitInitialSyncTimeout` option

- Guarantee up-to-date state on document load when opened by multiple instances.
- Introduce `awaitInitialSyncTimeout` for configurable sync delay.