### PR TITLE
fix: when beforeHandleMessage throws, we don't want to process other messages that were already queued

### DIFF
--- a/packages/server/src/Connection.ts
+++ b/packages/server/src/Connection.ts
@@ -293,6 +293,8 @@ export class Connection<Context = any> {
 					code: "code" in e && typeof e.code === 'number' ? e.code : ResetConnection.code,
 					reason: "reason" in e ? e.reason : ResetConnection.reason,
 				});
+				this.messageQueue.length = 0;
+				return;
 			}
 
 			this.messageQueue.shift();

--- a/tests/server/beforeHandleMessage.ts
+++ b/tests/server/beforeHandleMessage.ts
@@ -83,10 +83,18 @@ test('beforeHandleMessage callback is called for every new client', async t => {
 
 })
 
-test('an exception thrown in beforeHandleMessage closes the connection', async t => {
+test('an exception thrown in beforeHandleMessage closes the connection and discards queued messages', async t => {
+  let beforeHandleMessageCount = 0
+
   await new Promise(async resolve => {
     const server = await newHocuspocus(t, {
-      async beforeHandleMessage() {
+      async beforeHandleMessage({ connection, update }) {
+        beforeHandleMessageCount += 1
+
+        if (beforeHandleMessageCount === 1) {
+          connection.handleMessage(update)
+        }
+
         throw new Error()
       },
     })
@@ -98,4 +106,6 @@ test('an exception thrown in beforeHandleMessage closes the connection', async t
       },
     })
   })
+
+  t.is(beforeHandleMessageCount, 1)
 })


### PR DESCRIPTION
If you reject a message in beforeHandleMessage (e.g. during validation), the client is probably doing something weird and you don't want following messages (that were queued before the connection got closed) to be processed.