### PR TITLE
Feat/batch updates before sending to clients

### DIFF
--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -10,6 +10,7 @@ import { OutgoingMessage } from "./OutgoingMessage.ts";
 import type {
 	AwarenessUpdate,
 	ConnectionTransactionOrigin,
+	FlushOptions,
 	TransactionOrigin,
 } from "./types.ts";
 import { isTransactionOrigin } from "./types.ts";
@@ -52,12 +53,12 @@ export class Document extends Doc {
 	 * Batch outgoing broadcasts over this window (ms), or false to send each one
 	 * immediately. See `scheduleFlush`.
 	 */
-	flushDelay: false | number;
+	flushDelay: FlushOptions["flushDelay"];
 
 	/**
 	 * Flush early once this many bytes of document updates are buffered.
 	 */
-	flushMaxBytes: number;
+	flushMaxBytes: FlushOptions["flushMaxBytes"];
 
 	private pendingUpdates: Array<Uint8Array> = [];
 
@@ -73,7 +74,7 @@ export class Document extends Doc {
 	constructor(
 		name: string,
 		yDocOptions?: object,
-		options?: { flushDelay?: false | number; flushMaxBytes?: number },
+		options?: Partial<FlushOptions>,
 	) {
 		super(yDocOptions);
 
@@ -242,17 +243,6 @@ export class Document extends Doc {
 
 	/**
 	 * Handle an awareness update and sync changes to clients
-	 *
-	 * Connections that share a message address receive byte-identical payloads,
-	 * so consecutive connections with the same address reuse one buffer instead
-	 * of re-encoding per connection. With session awareness disabled (the
-	 * default) every connection on a document shares the plain document name,
-	 * which collapses the whole broadcast to a single encode.
-	 *
-	 * A one-entry cache rather than a Map keyed by address: it makes the common
-	 * cases optimal (all addresses equal, or all distinct) at no cost, and only
-	 * gives up dedup when addresses interleave, where it still matches the
-	 * previous encode-per-connection behaviour.
 	 * @private
 	 */
 	private handleAwarenessUpdate(
@@ -290,7 +280,22 @@ export class Document extends Doc {
 		return this;
 	}
 
-	private broadcastAwarenessUpdate(changedClients: Array<number>): void {
+	/**
+	 * Send one message to every connection, encoding it once per run of
+	 * connections that share a message address.
+	 *
+	 * Connections that share a message address receive byte-identical payloads,
+	 * so consecutive connections with the same address reuse one buffer instead
+	 * of re-encoding per connection. With session awareness disabled (the
+	 * default) every connection on a document shares the plain document name,
+	 * which collapses the whole broadcast to a single encode.
+	 *
+	 * A one-entry cache rather than a Map keyed by address: it makes the common
+	 * cases optimal (all addresses equal, or all distinct) at no cost, and only
+	 * gives up dedup when addresses interleave, where it still matches the
+	 * previous encode-per-connection behaviour.
+	 */
+	private broadcast(encode: (messageAddress: string) => Uint8Array): void {
 		let cachedAddress: string | undefined;
 		let cachedMessage: Uint8Array | undefined;
 
@@ -299,13 +304,19 @@ export class Document extends Doc {
 
 			if (cachedMessage === undefined || address !== cachedAddress) {
 				cachedAddress = address;
-				cachedMessage = new OutgoingMessage(address)
-					.createAwarenessUpdateMessage(this.awareness, changedClients)
-					.toUint8Array();
+				cachedMessage = encode(address);
 			}
 
 			connection.send(cachedMessage);
 		}
+	}
+
+	private broadcastAwarenessUpdate(changedClients: Array<number>): void {
+		this.broadcast((address) =>
+			new OutgoingMessage(address)
+				.createAwarenessUpdateMessage(this.awareness, changedClients)
+				.toUint8Array(),
+		);
 	}
 
 	/**
@@ -337,22 +348,12 @@ export class Document extends Doc {
 	}
 
 	private broadcastUpdate(update: Uint8Array): void {
-		let cachedAddress: string | undefined;
-		let cachedMessage: Uint8Array | undefined;
-
-		for (const connection of this.getConnections()) {
-			const address = connection.messageAddress;
-
-			if (cachedMessage === undefined || address !== cachedAddress) {
-				cachedAddress = address;
-				cachedMessage = new OutgoingMessage(address)
-					.createSyncMessage()
-					.writeUpdate(update)
-					.toUint8Array();
-			}
-
-			connection.send(cachedMessage);
-		}
+		this.broadcast((address) =>
+			new OutgoingMessage(address)
+				.createSyncMessage()
+				.writeUpdate(update)
+				.toUint8Array(),
+		);
 	}
 
 	/**

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -4,7 +4,7 @@ import {
 	applyAwarenessUpdate,
 	removeAwarenessStates,
 } from "y-protocols/awareness";
-import { applyUpdate, Doc, encodeStateAsUpdate } from "yjs";
+import { applyUpdate, Doc, encodeStateAsUpdate, mergeUpdates } from "yjs";
 import type Connection from "./Connection.ts";
 import { OutgoingMessage } from "./OutgoingMessage.ts";
 import type {
@@ -49,12 +49,37 @@ export class Document extends Doc {
 	lastChangeTime = 0;
 
 	/**
+	 * Batch outgoing broadcasts over this window (ms), or false to send each one
+	 * immediately. See `scheduleFlush`.
+	 */
+	flushDelay: false | number;
+
+	/**
+	 * Flush early once this many bytes of document updates are buffered.
+	 */
+	flushMaxBytes: number;
+
+	private pendingUpdates: Array<Uint8Array> = [];
+
+	private pendingUpdateBytes = 0;
+
+	private pendingAwarenessClients: Set<number> = new Set();
+
+	private cancelFlush: (() => void) | null = null;
+
+	/**
 	 * Constructor.
 	 */
-	constructor(name: string, yDocOptions?: object) {
+	constructor(
+		name: string,
+		yDocOptions?: object,
+		options?: { flushDelay?: false | number; flushMaxBytes?: number },
+	) {
 		super(yDocOptions);
 
 		this.name = name;
+		this.flushDelay = options?.flushDelay ?? false;
+		this.flushMaxBytes = options?.flushMaxBytes ?? 1024 * 1024;
 
 		this.awareness = new Awareness(this);
 		this.awareness.setLocalState(null);
@@ -250,6 +275,22 @@ export class Document extends Doc {
 			}
 		}
 
+		if (this.flushDelay === false) {
+			this.broadcastAwarenessUpdate(changedClients);
+
+			return this;
+		}
+
+		for (const clientId of changedClients) {
+			this.pendingAwarenessClients.add(clientId);
+		}
+
+		this.scheduleFlush();
+
+		return this;
+	}
+
+	private broadcastAwarenessUpdate(changedClients: Array<number>): void {
 		let cachedAddress: string | undefined;
 		let cachedMessage: Uint8Array | undefined;
 
@@ -265,16 +306,37 @@ export class Document extends Doc {
 
 			connection.send(cachedMessage);
 		}
-
-		return this;
 	}
 
 	/**
 	 * Handle an updated document and sync changes to clients
 	 */
 	private handleUpdate(update: Uint8Array, origin: unknown): Document {
+		// Stays synchronous even when broadcasts are batched: this drives
+		// `onChange`, the `onStoreDocument` debounce and the Redis publish in
+		// extension-redis. Deferring it would change persistence and cluster
+		// sync timing, not just the wire traffic.
 		this.callbacks.onUpdate(this, origin, update);
 
+		if (this.flushDelay === false) {
+			this.broadcastUpdate(update);
+
+			return this;
+		}
+
+		this.pendingUpdates.push(update);
+		this.pendingUpdateBytes += update.length;
+
+		if (this.pendingUpdateBytes >= this.flushMaxBytes) {
+			this.flush();
+		} else {
+			this.scheduleFlush();
+		}
+
+		return this;
+	}
+
+	private broadcastUpdate(update: Uint8Array): void {
 		let cachedAddress: string | undefined;
 		let cachedMessage: Uint8Array | undefined;
 
@@ -290,6 +352,74 @@ export class Document extends Doc {
 			}
 
 			connection.send(cachedMessage);
+		}
+	}
+
+	/**
+	 * Fixed-window batching: the first buffered change starts the window and
+	 * everything until it closes goes out together, so the added latency stays
+	 * capped at `flushDelay` instead of growing while clients keep typing.
+	 *
+	 * `flushDelay: 0` means "coalesce whatever arrives in this event loop turn".
+	 * setImmediate runs right after the current poll phase, so a burst of socket
+	 * reads is merged without adding any delay. `setTimeout(…, 0)` would not do
+	 * that: it clamps to 1ms and runs in the timers phase.
+	 */
+	private scheduleFlush(): void {
+		if (this.cancelFlush !== null) {
+			return;
+		}
+
+		const run = () => {
+			this.cancelFlush = null;
+			this.flush();
+		};
+
+		if (this.flushDelay === 0 && typeof setImmediate === "function") {
+			const handle = setImmediate(run);
+
+			this.cancelFlush = () => clearImmediate(handle);
+
+			return;
+		}
+
+		const handle = setTimeout(run, this.flushDelay as number);
+
+		this.cancelFlush = () => clearTimeout(handle);
+	}
+
+	/**
+	 * Send everything buffered for the current flush window right away. Document
+	 * updates are merged into a single message; awareness collapses to the latest
+	 * state of each changed client, so an add and a removal within one window
+	 * resolve to the correct end state rather than both being sent.
+	 *
+	 * Safe to call when nothing is pending.
+	 */
+	public flush(): Document {
+		if (this.cancelFlush !== null) {
+			this.cancelFlush();
+			this.cancelFlush = null;
+		}
+
+		if (this.pendingUpdates.length > 0) {
+			const update =
+				this.pendingUpdates.length === 1
+					? this.pendingUpdates[0]
+					: mergeUpdates(this.pendingUpdates);
+
+			this.pendingUpdates = [];
+			this.pendingUpdateBytes = 0;
+
+			this.broadcastUpdate(update);
+		}
+
+		if (this.pendingAwarenessClients.size > 0) {
+			const clients = Array.from(this.pendingAwarenessClients);
+
+			this.pendingAwarenessClients.clear();
+
+			this.broadcastAwarenessUpdate(clients);
 		}
 
 		return this;
@@ -314,6 +444,14 @@ export class Document extends Doc {
 	}
 
 	destroy() {
+		// Send what is still buffered instead of dropping it, then stop batching:
+		// `super.destroy()` tears the awareness down, which broadcasts one last
+		// time, and that has to reach clients here just as it does on a document
+		// that never batched. Usually a no-op, because a document is only
+		// unloaded once its last connection is gone.
+		this.flush();
+		this.flushDelay = false;
+
 		super.destroy();
 		this.isDestroyed = true;
 	}

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -4,15 +4,15 @@ import {
 	applyAwarenessUpdate,
 	removeAwarenessStates,
 } from "y-protocols/awareness";
-import { Doc, applyUpdate, encodeStateAsUpdate } from "yjs";
+import { applyUpdate, Doc, encodeStateAsUpdate } from "yjs";
 import type Connection from "./Connection.ts";
 import { OutgoingMessage } from "./OutgoingMessage.ts";
-import { isTransactionOrigin } from "./types.ts";
 import type {
 	AwarenessUpdate,
 	ConnectionTransactionOrigin,
 	TransactionOrigin,
 } from "./types.ts";
+import { isTransactionOrigin } from "./types.ts";
 
 export class Document extends Doc {
 	awareness: Awareness;
@@ -151,11 +151,7 @@ export class Document extends Doc {
 	removeConnection(connection: Connection): Document {
 		const entry = this.connections.get(connection);
 		if (entry) {
-			removeAwarenessStates(
-				this.awareness,
-				Array.from(entry.clients),
-				null,
-			);
+			removeAwarenessStates(this.awareness, Array.from(entry.clients), null);
 		}
 
 		this.connections.delete(connection);
@@ -221,6 +217,17 @@ export class Document extends Doc {
 
 	/**
 	 * Handle an awareness update and sync changes to clients
+	 *
+	 * Connections that share a message address receive byte-identical payloads,
+	 * so consecutive connections with the same address reuse one buffer instead
+	 * of re-encoding per connection. With session awareness disabled (the
+	 * default) every connection on a document shares the plain document name,
+	 * which collapses the whole broadcast to a single encode.
+	 *
+	 * A one-entry cache rather than a Map keyed by address: it makes the common
+	 * cases optimal (all addresses equal, or all distinct) at no cost, and only
+	 * gives up dedup when addresses interleave, where it still matches the
+	 * previous encode-per-connection behaviour.
 	 * @private
 	 */
 	private handleAwarenessUpdate(
@@ -243,12 +250,20 @@ export class Document extends Doc {
 			}
 		}
 
-		for (const connection of this.getConnections()) {
-			const awarenessMessage = new OutgoingMessage(
-				connection.messageAddress,
-			).createAwarenessUpdateMessage(this.awareness, changedClients);
+		let cachedAddress: string | undefined;
+		let cachedMessage: Uint8Array | undefined;
 
-			connection.send(awarenessMessage.toUint8Array());
+		for (const connection of this.getConnections()) {
+			const address = connection.messageAddress;
+
+			if (cachedMessage === undefined || address !== cachedAddress) {
+				cachedAddress = address;
+				cachedMessage = new OutgoingMessage(address)
+					.createAwarenessUpdateMessage(this.awareness, changedClients)
+					.toUint8Array();
+			}
+
+			connection.send(cachedMessage);
 		}
 
 		return this;
@@ -260,12 +275,21 @@ export class Document extends Doc {
 	private handleUpdate(update: Uint8Array, origin: unknown): Document {
 		this.callbacks.onUpdate(this, origin, update);
 
-		for (const connection of this.getConnections()) {
-			const message = new OutgoingMessage(connection.messageAddress)
-				.createSyncMessage()
-				.writeUpdate(update);
+		let cachedAddress: string | undefined;
+		let cachedMessage: Uint8Array | undefined;
 
-			connection.send(message.toUint8Array());
+		for (const connection of this.getConnections()) {
+			const address = connection.messageAddress;
+
+			if (cachedMessage === undefined || address !== cachedAddress) {
+				cachedAddress = address;
+				cachedMessage = new OutgoingMessage(address)
+					.createSyncMessage()
+					.writeUpdate(update)
+					.toUint8Array();
+			}
+
+			connection.send(cachedMessage);
 		}
 
 		return this;

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -79,7 +79,7 @@ export class Document extends Doc {
 		super(yDocOptions);
 
 		this.name = name;
-		this.flushDelay = options?.flushDelay ?? false;
+		this.flushDelay = options?.flushDelay ?? 0;
 		this.flushMaxBytes = options?.flushMaxBytes ?? 1024 * 1024;
 
 		this.awareness = new Awareness(this);

--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -295,11 +295,18 @@ export class Document extends Doc {
 	 * gives up dedup when addresses interleave, where it still matches the
 	 * previous encode-per-connection behaviour.
 	 */
-	private broadcast(encode: (messageAddress: string) => Uint8Array): void {
+	private broadcast(
+		encode: (messageAddress: string) => Uint8Array,
+		filter?: (connection: Connection) => boolean,
+	): void {
 		let cachedAddress: string | undefined;
 		let cachedMessage: Uint8Array | undefined;
 
 		for (const connection of this.getConnections()) {
+			if (filter !== undefined && !filter(connection)) {
+				continue;
+			}
+
 			const address = connection.messageAddress;
 
 			if (cachedMessage === undefined || address !== cachedAddress) {
@@ -428,6 +435,12 @@ export class Document extends Doc {
 
 	/**
 	 * Broadcast stateless message to all connections
+	 *
+	 * Shares one encoded buffer per message address like the update and awareness
+	 * broadcasts. Not batched, though: stateless payloads are opaque discrete
+	 * events, so unlike updates they cannot be merged and unlike awareness they
+	 * do not collapse to a latest state — deferring them would delay delivery
+	 * without reducing the number of messages.
 	 */
 	public broadcastStateless(
 		payload: string,
@@ -435,13 +448,11 @@ export class Document extends Doc {
 	): void {
 		this.callbacks.beforeBroadcastStateless(this, payload);
 
-		const connections = filter
-			? this.getConnections().filter(filter)
-			: this.getConnections();
-
-		connections.forEach((connection) => {
-			connection.sendStateless(payload);
-		});
+		this.broadcast(
+			(address) =>
+				new OutgoingMessage(address).writeStateless(payload).toUint8Array(),
+			filter,
+		);
 	}
 
 	destroy() {

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -37,6 +37,8 @@ export const defaultConfiguration = {
 	maxUnauthenticatedQueueSize: 5 * 1024 * 1024,
 	maxUnauthenticatedQueueMessages: 1_000,
 	maxPendingDocuments: 100,
+	flushDelay: false as false | number,
+	flushMaxBytes: 1024 * 1024,
 };
 
 export class Hocuspocus<Context = any> {
@@ -390,10 +392,17 @@ export class Hocuspocus<Context = any> {
 			instance: this,
 		});
 
-		const document = new Document(documentName, {
-			...this.configuration.yDocOptions,
-			...yDocOptions,
-		});
+		const document = new Document(
+			documentName,
+			{
+				...this.configuration.yDocOptions,
+				...yDocOptions,
+			},
+			{
+				flushDelay: this.configuration.flushDelay,
+				flushMaxBytes: this.configuration.flushMaxBytes,
+			},
+		);
 
 		const hookPayload = {
 			instance: this,

--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -37,7 +37,7 @@ export const defaultConfiguration = {
 	maxUnauthenticatedQueueSize: 5 * 1024 * 1024,
 	maxUnauthenticatedQueueMessages: 1_000,
 	maxPendingDocuments: 100,
-	flushDelay: false as false | number,
+	flushDelay: 0 as false | number,
 	flushMaxBytes: 1024 * 1024,
 };
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -203,17 +203,26 @@ export interface FlushOptions {
 	 * many connected clients sends `connections` messages per window rather than
 	 * `changes × connections`.
 	 *
-	 * `0` is the recommended starting point: it flushes at the end of the current
-	 * event loop turn, which coalesces a burst of simultaneous updates without
-	 * adding any latency. A positive value trades up to that much extra latency
-	 * for more aggressive merging, and is only a win when several changes
+	 * The default `0` flushes at the end of the current event loop turn. It adds
+	 * no delay — a burst of updates that arrived together is coalesced before
+	 * anything is written to a socket — and with a single writer no merge happens
+	 * at all, because there is only one buffered update to send. On a document
+	 * with many writing clients the difference is large: 2000 clients each
+	 * writing once produces 2000 broadcast messages per turn instead of
+	 * 2000 × 2000.
+	 *
+	 * A positive value additionally merges across turns, trading up to that much
+	 * latency for fewer messages. That is only a win when several changes
 	 * genuinely land per window — with a handful of clients typing it is pure
-	 * added delay.
+	 * added delay, so prefer `0` unless you have measured otherwise.
+	 *
+	 * `false` restores the pre-batching behaviour and sends every broadcast
+	 * synchronously, inside the same tick that applied the change.
 	 *
 	 * Applies to the WebSocket fan-out only. `onChange`, the `onStoreDocument`
 	 * debounce and the Redis publish still run synchronously per change.
 	 *
-	 * @default false (send each broadcast immediately)
+	 * @default 0 (coalesce within the current event loop turn)
 	 */
 	flushDelay: false | number;
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -190,7 +190,46 @@ export type HookPayloadByName<Context = any> = {
 	onDestroy: onDestroyPayload;
 };
 
-export interface Configuration<Context = any> extends Extension<Context> {
+/**
+ * Controls how a document batches its outgoing broadcasts. Shared by the server
+ * configuration and the `Document` constructor so both stay in step.
+ */
+export interface FlushOptions {
+	/**
+	 * Batch outgoing broadcasts per document over a window of this many
+	 * milliseconds, instead of sending one message per connection per change.
+	 * Updates within a window are merged into a single message and awareness
+	 * collapses to the latest state of each changed client, so a document with
+	 * many connected clients sends `connections` messages per window rather than
+	 * `changes × connections`.
+	 *
+	 * `0` is the recommended starting point: it flushes at the end of the current
+	 * event loop turn, which coalesces a burst of simultaneous updates without
+	 * adding any latency. A positive value trades up to that much extra latency
+	 * for more aggressive merging, and is only a win when several changes
+	 * genuinely land per window — with a handful of clients typing it is pure
+	 * added delay.
+	 *
+	 * Applies to the WebSocket fan-out only. `onChange`, the `onStoreDocument`
+	 * debounce and the Redis publish still run synchronously per change.
+	 *
+	 * @default false (send each broadcast immediately)
+	 */
+	flushDelay: false | number;
+
+	/**
+	 * Flush a document's batched broadcasts early once this many bytes of updates
+	 * are buffered, bounding both the memory held per window and the cost of the
+	 * merge. Ignored when `flushDelay` is false.
+	 *
+	 * @default 1_048_576 (1 MiB)
+	 */
+	flushMaxBytes: number;
+}
+
+export interface Configuration<Context = any>
+	extends Extension<Context>,
+		FlushOptions {
 	/**
 	 * A name for the instance, used for logging.
 	 */
@@ -252,37 +291,6 @@ export interface Configuration<Context = any> extends Extension<Context> {
 	 * @default 100
 	 */
 	maxPendingDocuments: number;
-
-	/**
-	 * Batch outgoing broadcasts per document over a window of this many
-	 * milliseconds, instead of sending one message per connection per change.
-	 * Updates within a window are merged into a single message and awareness
-	 * collapses to the latest state of each changed client, so a document with
-	 * many connected clients sends `connections` messages per window rather than
-	 * `changes × connections`.
-	 *
-	 * `0` is the recommended starting point: it flushes at the end of the current
-	 * event loop turn, which coalesces a burst of simultaneous updates without
-	 * adding any latency. A positive value trades up to that much extra latency
-	 * for more aggressive merging, and is only a win when several changes
-	 * genuinely land per window — with a handful of clients typing it is pure
-	 * added delay.
-	 *
-	 * Applies to the WebSocket fan-out only. `onChange`, the `onStoreDocument`
-	 * debounce and the Redis publish still run synchronously per change.
-	 *
-	 * @default false (send each broadcast immediately)
-	 */
-	flushDelay: false | number;
-
-	/**
-	 * Flush a document's batched broadcasts early once this many bytes of updates
-	 * are buffered, bounding both the memory held per window and the cost of the
-	 * merge. Ignored when `flushDelay` is false.
-	 *
-	 * @default 1_048_576 (1 MiB)
-	 */
-	flushMaxBytes: number;
 
 	/**
 	 * options to pass to the ydoc document

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -254,6 +254,37 @@ export interface Configuration<Context = any> extends Extension<Context> {
 	maxPendingDocuments: number;
 
 	/**
+	 * Batch outgoing broadcasts per document over a window of this many
+	 * milliseconds, instead of sending one message per connection per change.
+	 * Updates within a window are merged into a single message and awareness
+	 * collapses to the latest state of each changed client, so a document with
+	 * many connected clients sends `connections` messages per window rather than
+	 * `changes × connections`.
+	 *
+	 * `0` is the recommended starting point: it flushes at the end of the current
+	 * event loop turn, which coalesces a burst of simultaneous updates without
+	 * adding any latency. A positive value trades up to that much extra latency
+	 * for more aggressive merging, and is only a win when several changes
+	 * genuinely land per window — with a handful of clients typing it is pure
+	 * added delay.
+	 *
+	 * Applies to the WebSocket fan-out only. `onChange`, the `onStoreDocument`
+	 * debounce and the Redis publish still run synchronously per change.
+	 *
+	 * @default false (send each broadcast immediately)
+	 */
+	flushDelay: false | number;
+
+	/**
+	 * Flush a document's batched broadcasts early once this many bytes of updates
+	 * are buffered, bounding both the memory held per window and the cost of the
+	 * merge. Ignored when `flushDelay` is false.
+	 *
+	 * @default 1_048_576 (1 MiB)
+	 */
+	flushMaxBytes: number;
+
+	/**
 	 * options to pass to the ydoc document
 	 */
 	yDocOptions: {

--- a/tests/server/broadcastEncoding.ts
+++ b/tests/server/broadcastEncoding.ts
@@ -1,0 +1,104 @@
+import test from 'ava'
+import { makeRoutingKey } from '@hocuspocus/common'
+import { Document } from '@hocuspocus/server'
+import * as decoding from 'lib0/decoding'
+
+type FakeConnection = {
+  messageAddress: string
+  sent: Uint8Array[]
+  send: (message: Uint8Array) => void
+}
+
+/**
+ * Registers a minimal stand-in for a Connection. `handleUpdate` and
+ * `handleAwarenessUpdate` only read `messageAddress` and call `send`, so a
+ * duck-typed object is enough to observe what the broadcast produces.
+ */
+const addConnection = (document: Document, messageAddress: string): FakeConnection => {
+  const connection: FakeConnection = {
+    messageAddress,
+    sent: [],
+    send(message: Uint8Array) {
+      this.sent.push(message)
+    },
+  }
+
+  document.connections.set(connection as any, { clients: new Set() })
+
+  return connection
+}
+
+const readAddress = (message: Uint8Array) => decoding.readVarString(decoding.createDecoder(message))
+
+test('encodes a document update once and shares it across connections', t => {
+  const document = new Document('hocuspocus-test')
+
+  const first = addConnection(document, 'hocuspocus-test')
+  const second = addConnection(document, 'hocuspocus-test')
+  const third = addConnection(document, 'hocuspocus-test')
+
+  document.getMap('test').set('foo', 'bar')
+
+  t.is(first.sent.length, 1)
+  t.is(second.sent.length, 1)
+  t.is(third.sent.length, 1)
+
+  // The same buffer instance reaches every connection, so it was encoded once.
+  t.is(first.sent[0], second.sent[0])
+  t.is(first.sent[0], third.sent[0])
+})
+
+test('encodes an awareness update once and shares it across connections', t => {
+  const document = new Document('hocuspocus-test')
+
+  const first = addConnection(document, 'hocuspocus-test')
+  const second = addConnection(document, 'hocuspocus-test')
+
+  document.awareness.setLocalState({ foo: 'bar' })
+
+  t.is(first.sent.length, 1)
+  t.is(second.sent.length, 1)
+  t.is(first.sent[0], second.sent[0])
+})
+
+test('reuses the buffer across consecutive connections sharing an address', t => {
+  const document = new Document('hocuspocus-test')
+
+  const legacy = addConnection(document, 'hocuspocus-test')
+  const sessionA = addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a'))
+  const sessionAToo = addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a'))
+  const sessionB = addConnection(document, makeRoutingKey('hocuspocus-test', 'session-b'))
+
+  document.getMap('test').set('foo', 'bar')
+
+  t.is(sessionA.sent[0], sessionAToo.sent[0])
+  t.not(legacy.sent[0], sessionA.sent[0])
+  t.not(sessionA.sent[0], sessionB.sent[0])
+
+  const buffers = new Set([legacy.sent[0], sessionA.sent[0], sessionAToo.sent[0], sessionB.sent[0]])
+  t.is(buffers.size, 3)
+})
+
+test('addresses every broadcast message to the receiving connection', t => {
+  const document = new Document('hocuspocus-test')
+
+  // Interleaved addresses: buffer reuse does not apply here, so this also
+  // covers the fallback path where every connection gets its own encode.
+  const connections = [
+    addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a')),
+    addConnection(document, 'hocuspocus-test'),
+    addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a')),
+    addConnection(document, makeRoutingKey('hocuspocus-test', 'session-b')),
+  ]
+
+  document.getMap('test').set('foo', 'bar')
+  document.awareness.setLocalState({ foo: 'bar' })
+
+  for (const connection of connections) {
+    t.is(connection.sent.length, 2)
+
+    for (const message of connection.sent) {
+      t.is(readAddress(message), connection.messageAddress)
+    }
+  }
+})

--- a/tests/server/broadcastEncoding.ts
+++ b/tests/server/broadcastEncoding.ts
@@ -67,6 +67,49 @@ test('encodes an awareness update once and shares it across connections', t => {
   t.is(first.sent[0], second.sent[0])
 })
 
+test('encodes a stateless broadcast once and shares it across connections', t => {
+  const document = newDocument()
+
+  const first = addConnection(document, 'hocuspocus-test')
+  const second = addConnection(document, 'hocuspocus-test')
+
+  document.broadcastStateless('{"event":"document.saved"}')
+
+  t.is(first.sent.length, 1)
+  t.is(second.sent.length, 1)
+  t.is(first.sent[0], second.sent[0])
+})
+
+test('a filtered stateless broadcast only reaches matching connections', t => {
+  const document = newDocument()
+
+  const first = addConnection(document, 'hocuspocus-test')
+  const skipped = addConnection(document, 'hocuspocus-test')
+  const third = addConnection(document, 'hocuspocus-test')
+
+  document.broadcastStateless('{"event":"document.saved"}', connection => connection !== (skipped as any))
+
+  t.is(first.sent.length, 1)
+  t.is(skipped.sent.length, 0)
+  t.is(third.sent.length, 1)
+
+  // A skipped connection in the middle must not cost the others their shared buffer.
+  t.is(first.sent[0], third.sent[0])
+})
+
+test('addresses stateless broadcasts per connection', t => {
+  const document = newDocument()
+
+  const legacy = addConnection(document, 'hocuspocus-test')
+  const session = addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a'))
+
+  document.broadcastStateless('{"event":"document.saved"}')
+
+  t.is(readAddress(legacy.sent[0]), 'hocuspocus-test')
+  t.is(readAddress(session.sent[0]), makeRoutingKey('hocuspocus-test', 'session-a'))
+  t.not(legacy.sent[0], session.sent[0])
+})
+
 test('reuses the buffer across consecutive connections sharing an address', t => {
   const document = newDocument()
 

--- a/tests/server/broadcastEncoding.ts
+++ b/tests/server/broadcastEncoding.ts
@@ -10,9 +10,15 @@ type FakeConnection = {
 }
 
 /**
- * Registers a minimal stand-in for a Connection. `handleUpdate` and
- * `handleAwarenessUpdate` only read `messageAddress` and call `send`, so a
- * duck-typed object is enough to observe what the broadcast produces.
+ * Encoding is identical batched or not, so these tests opt out of batching to
+ * keep every assertion synchronous.
+ */
+const newDocument = () => new Document('hocuspocus-test', undefined, { flushDelay: false })
+
+/**
+ * Registers a minimal stand-in for a Connection. The broadcast paths only read
+ * `messageAddress` and call `send`, so a duck-typed object is enough to observe
+ * what they produce.
  */
 const addConnection = (document: Document, messageAddress: string): FakeConnection => {
   const connection: FakeConnection = {
@@ -31,7 +37,7 @@ const addConnection = (document: Document, messageAddress: string): FakeConnecti
 const readAddress = (message: Uint8Array) => decoding.readVarString(decoding.createDecoder(message))
 
 test('encodes a document update once and shares it across connections', t => {
-  const document = new Document('hocuspocus-test')
+  const document = newDocument()
 
   const first = addConnection(document, 'hocuspocus-test')
   const second = addConnection(document, 'hocuspocus-test')
@@ -49,7 +55,7 @@ test('encodes a document update once and shares it across connections', t => {
 })
 
 test('encodes an awareness update once and shares it across connections', t => {
-  const document = new Document('hocuspocus-test')
+  const document = newDocument()
 
   const first = addConnection(document, 'hocuspocus-test')
   const second = addConnection(document, 'hocuspocus-test')
@@ -62,7 +68,7 @@ test('encodes an awareness update once and shares it across connections', t => {
 })
 
 test('reuses the buffer across consecutive connections sharing an address', t => {
-  const document = new Document('hocuspocus-test')
+  const document = newDocument()
 
   const legacy = addConnection(document, 'hocuspocus-test')
   const sessionA = addConnection(document, makeRoutingKey('hocuspocus-test', 'session-a'))
@@ -80,7 +86,7 @@ test('reuses the buffer across consecutive connections sharing an address', t =>
 })
 
 test('addresses every broadcast message to the receiving connection', t => {
-  const document = new Document('hocuspocus-test')
+  const document = newDocument()
 
   // Interleaved addresses: buffer reuse does not apply here, so this also
   // covers the fallback path where every connection gets its own encode.

--- a/tests/server/flushDelay.ts
+++ b/tests/server/flushDelay.ts
@@ -1,0 +1,247 @@
+import test from 'ava'
+import { Document } from '@hocuspocus/server'
+import * as decoding from 'lib0/decoding'
+import * as Y from 'yjs'
+import { newHocuspocus, newHocuspocusProvider } from '../utils/index.ts'
+import { retryableAssertion } from '../utils/retryableAssertion.ts'
+
+type FakeConnection = {
+  messageAddress: string
+  sent: Uint8Array[]
+  send: (message: Uint8Array) => void
+}
+
+const addConnection = (document: Document): FakeConnection => {
+  const connection: FakeConnection = {
+    messageAddress: document.name,
+    sent: [],
+    send(message: Uint8Array) {
+      this.sent.push(message)
+    },
+  }
+
+  document.connections.set(connection as any, { clients: new Set() })
+
+  return connection
+}
+
+/** Resolves after the flush scheduled with `flushDelay: 0` has run. */
+const tick = () => new Promise(resolve => setImmediate(resolve))
+
+const readUpdate = (message: Uint8Array) => {
+  const decoder = decoding.createDecoder(message)
+
+  decoding.readVarString(decoder) // message address
+  decoding.readVarUint(decoder) // MessageType.Sync
+  decoding.readVarUint(decoder) // messageYjsUpdate
+
+  return decoding.readVarUint8Array(decoder)
+}
+
+const readAwarenessStates = (message: Uint8Array) => {
+  const decoder = decoding.createDecoder(message)
+
+  decoding.readVarString(decoder) // message address
+  decoding.readVarUint(decoder) // MessageType.Awareness
+
+  const payload = decoding.createDecoder(decoding.readVarUint8Array(decoder))
+  const states = new Map<number, any>()
+  const count = decoding.readVarUint(payload)
+
+  for (let i = 0; i < count; i += 1) {
+    const clientId = decoding.readVarUint(payload)
+
+    decoding.readVarUint(payload) // clock
+    states.set(clientId, JSON.parse(decoding.readVarString(payload)))
+  }
+
+  return states
+}
+
+test('sends one message per change when flushDelay is false', t => {
+  const document = new Document('hocuspocus-test')
+  const connection = addConnection(document)
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+  document.getMap('test').set('c', 3)
+
+  t.is(connection.sent.length, 3)
+})
+
+test('merges updates from the same tick into a single message', async t => {
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const connection = addConnection(document)
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+  document.getMap('test').set('c', 3)
+
+  // Nothing goes out synchronously; the flush is scheduled for the end of the turn.
+  t.is(connection.sent.length, 0)
+
+  await tick()
+
+  t.is(connection.sent.length, 1)
+})
+
+test('the merged message carries every buffered change', async t => {
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const connection = addConnection(document)
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+  document.getMap('test').set('c', 3)
+
+  await tick()
+
+  const target = new Y.Doc()
+
+  Y.applyUpdate(target, readUpdate(connection.sent[0]))
+
+  const map = target.getMap('test')
+
+  t.is(map.get('a'), 1)
+  t.is(map.get('b'), 2)
+  t.is(map.get('c'), 3)
+})
+
+test('collapses awareness changes to the latest state of each client', async t => {
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const connection = addConnection(document)
+
+  document.awareness.setLocalState({ cursor: 1 })
+  document.awareness.setLocalState({ cursor: 2 })
+  document.awareness.setLocalState({ cursor: 3 })
+
+  t.is(connection.sent.length, 0)
+
+  await tick()
+
+  t.is(connection.sent.length, 1)
+
+  const states = readAwarenessStates(connection.sent[0])
+
+  t.is(states.size, 1)
+  t.is(states.get(document.clientID).cursor, 3)
+})
+
+test('flushes early once flushMaxBytes is buffered', t => {
+  const document = new Document('hocuspocus-test', undefined, {
+    flushDelay: 0,
+    flushMaxBytes: 1,
+  })
+  const connection = addConnection(document)
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+
+  // Every update trips the limit, so each is sent without waiting for the flush.
+  t.is(connection.sent.length, 2)
+})
+
+test('calls onUpdate synchronously for every change even when batching', t => {
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const connection = addConnection(document)
+
+  let updates = 0
+
+  document.callbacks.onUpdate = () => {
+    updates += 1
+  }
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+  document.getMap('test').set('c', 3)
+
+  // The broadcast is deferred, the hook that drives onChange / onStoreDocument
+  // and the Redis publish is not.
+  t.is(updates, 3)
+  t.is(connection.sent.length, 0)
+})
+
+test('flush is a no-op when nothing is pending', t => {
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const connection = addConnection(document)
+
+  document.flush()
+  document.flush()
+
+  t.is(connection.sent.length, 0)
+})
+
+test('destroy flushes what is still buffered instead of dropping it', async t => {
+  const batched = new Document('hocuspocus-test', undefined, { flushDelay: 0 })
+  const batchedConnection = addConnection(batched)
+
+  batched.getMap('test').set('a', 1)
+
+  t.is(batchedConnection.sent.length, 0)
+
+  batched.destroy()
+
+  // Everything is out by the time destroy returns, and nothing is scheduled
+  // afterwards.
+  const afterDestroy = batchedConnection.sent.length
+
+  await tick()
+
+  t.is(batchedConnection.sent.length, afterDestroy)
+
+  // The same document without batching emits exactly as many messages: the
+  // buffered update plus the awareness teardown that destroy triggers.
+  const unbatched = new Document('hocuspocus-test')
+  const unbatchedConnection = addConnection(unbatched)
+
+  unbatched.getMap('test').set('a', 1)
+  unbatched.destroy()
+
+  t.is(batchedConnection.sent.length, unbatchedConnection.sent.length)
+})
+
+test('a batching server still converges on connected clients', async t => {
+  const server = await newHocuspocus(t, { flushDelay: 0 })
+
+  const writer = newHocuspocusProvider(t, server, { name: 'flush-converge' })
+  const reader = newHocuspocusProvider(t, server, { name: 'flush-converge' })
+
+  await new Promise(resolve => reader.on('synced', () => resolve('done')))
+
+  writer.document.getMap('test').set('a', 1)
+  writer.document.getMap('test').set('b', 2)
+  writer.document.getMap('test').set('c', 3)
+
+  await retryableAssertion(t, tt => {
+    const map = reader.document.getMap('test')
+
+    tt.is(map.get('a'), 1)
+    tt.is(map.get('b'), 2)
+    tt.is(map.get('c'), 3)
+  })
+})
+
+test('onChange still fires per change when batching is enabled', async t => {
+  let changes = 0
+
+  const server = await newHocuspocus(t, {
+    flushDelay: 0,
+    async onChange() {
+      changes += 1
+    },
+  })
+
+  const provider = newHocuspocusProvider(t, server, {
+    name: 'flush-onchange',
+    awareness: null,
+  })
+
+  await new Promise(resolve => provider.on('synced', () => resolve('done')))
+
+  provider.document.getMap('test').set('a', 1)
+  provider.document.getMap('test').set('b', 2)
+  provider.document.getMap('test').set('c', 3)
+
+  await retryableAssertion(t, tt => {
+    tt.is(changes, 3)
+  })
+})

--- a/tests/server/flushDelay.ts
+++ b/tests/server/flushDelay.ts
@@ -59,7 +59,7 @@ const readAwarenessStates = (message: Uint8Array) => {
 }
 
 test('sends one message per change when flushDelay is false', t => {
-  const document = new Document('hocuspocus-test')
+  const document = new Document('hocuspocus-test', undefined, { flushDelay: false })
   const connection = addConnection(document)
 
   document.getMap('test').set('a', 1)
@@ -67,6 +67,27 @@ test('sends one message per change when flushDelay is false', t => {
   document.getMap('test').set('c', 3)
 
   t.is(connection.sent.length, 3)
+})
+
+test('batches by default', async t => {
+  const document = new Document('hocuspocus-test')
+  const connection = addConnection(document)
+
+  document.getMap('test').set('a', 1)
+  document.getMap('test').set('b', 2)
+
+  t.is(document.flushDelay, 0)
+  t.is(connection.sent.length, 0)
+
+  await tick()
+
+  t.is(connection.sent.length, 1)
+})
+
+test('a server batches by default', async t => {
+  const server = await newHocuspocus(t)
+
+  t.is(server.configuration.flushDelay, 0)
 })
 
 test('merges updates from the same tick into a single message', async t => {
@@ -190,7 +211,7 @@ test('destroy flushes what is still buffered instead of dropping it', async t =>
 
   // The same document without batching emits exactly as many messages: the
   // buffered update plus the awareness teardown that destroy triggers.
-  const unbatched = new Document('hocuspocus-test')
+  const unbatched = new Document('hocuspocus-test', undefined, { flushDelay: false })
   const unbatchedConnection = addConnection(unbatched)
 
   unbatched.getMap('test').set('a', 1)

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -300,6 +300,11 @@ test("if a new connection connects while the previous connection still fetches t
 		};
 
 		const server = await newHocuspocus(t, {
+			// This test asserts on the document state at each individual inbound
+			// message, so it pins the unbatched fan-out. With the default
+			// `flushDelay: 0` a broadcast lands one event loop turn later, which
+			// reorders it relative to the sync acks and shifts these indices.
+			flushDelay: false,
 			onLoadDocument({ document }) {
 				return new Promise(async (resolve) => {
 					setTimeout(() => {


### PR DESCRIPTION
When a lot of users connect to the same document really fast after the other, or all of them are emitting changes at around the same time (reproduced with 400+ users on a single doc that apply changes), the server may end up with a blocked main loop because every change is sent to every user. So if you have 400 users changing the doc, the server loops through 400 changes and each time loops through 400 users to emit the update, easily ending up with a few hundred thousand messsages sent).

This feature allows the server to merge updates if they arrive within `flushDelay` and thus significantly reduce the number of messages sent, while only adding a slight delay.

The default `flushDelay` is just a `setImmediate`. It can be set to any number in milliseconds (also `0` which is the default), or `false` to turn it off.