### PR TITLE
fix: encode stateless message once when received operation via Redis …

### DIFF
--- a/packages/server/src/Document.ts
+++ b/packages/server/src/Document.ts
@@ -448,6 +448,21 @@ export class Document extends Doc {
 	): void {
 		this.callbacks.beforeBroadcastStateless(this, payload);
 
+		this.relayStateless(payload, filter);
+	}
+
+	/**
+	 * Send a stateless payload to this instance's connections *without* running
+	 * the `beforeBroadcastStateless` hook.
+	 *
+	 * For relaying a payload that another server instance already broadcast: the
+	 * hook ran there, and running it again here would fire it once per instance.
+	 * Prefer `broadcastStateless` unless you are that relay.
+	 */
+	public relayStateless(
+		payload: string,
+		filter?: (conn: Connection) => boolean,
+	): void {
 		this.broadcast(
 			(address) =>
 				new OutgoingMessage(address).writeStateless(payload).toUint8Array(),

--- a/packages/server/src/MessageReceiver.ts
+++ b/packages/server/src/MessageReceiver.ts
@@ -137,9 +137,12 @@ export class MessageReceiver {
 					);
 				}
 				const msg = message.readVarString();
-				document.getConnections().forEach((c) => {
-					c.sendStateless(msg);
-				});
+				// `relayStateless`, not `broadcastStateless`: the originating
+				// instance already ran the beforeBroadcastStateless hook. It shares
+				// one encoded buffer across connections instead of encoding per
+				// connection, which matters here because this path fans out on
+				// every instance of a cluster.
+				document.relayStateless(msg);
 				break;
 			}
 


### PR DESCRIPTION
…; this is a performance fix.