### PR TITLE
Add survey callout to server README

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -6,6 +6,10 @@
 
 The collaborative editing backend for [Tiptap](https://github.com/ueberdosis/tiptap). Built on [Y.js](https://github.com/yjs/yjs), runs on Node.js (22+), Bun, Deno, and Cloudflare Workers.
 
+> [!TIP]
+> Help us **chart the future of Hocuspocus** by telling us about your needs in a short survey. Plus, you’ll get a chance to earn a $50 gift card.
+> **[Take the survey →](https://docs.google.com/forms/d/e/1FAIpQLSeUS8S1iZTud58GBSD_d4c8lfUvkZHvzU99kWxP1wnNZnPKpw/viewform?usp=header)**
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This adds the same callout to the server package README that we added to the main README earlier.