### PR TITLE
fix: emit maxAttemptsFailed instead of unhandled rejection

### DIFF
--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -13,6 +13,7 @@ import {
 	type onAwarenessUpdateParameters,
 	type onCloseParameters,
 	type onDisconnectParameters,
+	type onMaxAttemptsFailedParameters,
 	type onMessageParameters,
 	type onOpenParameters,
 	type onOutgoingMessageParameters,
@@ -94,6 +95,7 @@ export interface CompleteHocuspocusProviderWebsocketConfiguration {
 	onStatus: (data: onStatusParameters) => void;
 	onDisconnect: (data: onDisconnectParameters) => void;
 	onClose: (data: onCloseParameters) => void;
+	onMaxAttemptsFailed: (data: onMaxAttemptsFailedParameters) => void;
 	onDestroy: () => void;
 	onAwarenessUpdate: (data: onAwarenessUpdateParameters) => void;
 	onAwarenessChange: (data: onAwarenessChangeParameters) => void;
@@ -144,6 +146,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 		onStatus: () => null,
 		onDisconnect: () => null,
 		onClose: () => null,
+		onMaxAttemptsFailed: () => null,
 		onDestroy: () => null,
 		onAwarenessUpdate: () => null,
 		onAwarenessChange: () => null,
@@ -188,6 +191,7 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 		this.on("status", this.configuration.onStatus);
 		this.on("disconnect", this.configuration.onDisconnect);
 		this.on("close", this.configuration.onClose);
+		this.on("maxAttemptsFailed", this.configuration.onMaxAttemptsFailed);
 		this.on("destroy", this.configuration.onDestroy);
 		this.on("awarenessUpdate", this.configuration.onAwarenessUpdate);
 		this.on("awarenessChange", this.configuration.onAwarenessChange);
@@ -301,7 +305,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 				// If we aborted the connection attempt then don’t throw an error
 				// ref: https://github.com/lifeomic/attempt/blob/master/src/index.ts#L136
 				if (error && error.code !== "ATTEMPT_ABORTED") {
-					throw error;
+					// connect() is fire-and-forget; rethrowing becomes an unhandled rejection.
+					this.emit("maxAttemptsFailed", { error });
 				}
 			});
 

--- a/packages/provider/src/HocuspocusProviderWebsocket.ts
+++ b/packages/provider/src/HocuspocusProviderWebsocket.ts
@@ -302,9 +302,9 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 					}
 				},
 			}).catch((error: any) => {
-				// If we aborted the connection attempt then don’t throw an error
+				// If we aborted the connection attempt then don’t report a failure
 				// ref: https://github.com/lifeomic/attempt/blob/master/src/index.ts#L136
-				if (error && error.code !== "ATTEMPT_ABORTED") {
+				if (error?.code !== "ATTEMPT_ABORTED") {
 					// connect() is fire-and-forget; rethrowing becomes an unhandled rejection.
 					this.emit("maxAttemptsFailed", { error });
 				}
@@ -443,8 +443,8 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 		this.connectionAttempt = null;
 	}
 
-	rejectConnectionAttempt() {
-		this.connectionAttempt?.reject();
+	rejectConnectionAttempt(reason?: unknown) {
+		this.connectionAttempt?.reject(reason);
 		this.connectionAttempt = null;
 	}
 
@@ -568,8 +568,14 @@ export class HocuspocusProviderWebsocket extends EventEmitter {
 		this.cleanupWebSocket();
 
 		if (this.connectionAttempt) {
-			// That connection attempt failed.
-			this.rejectConnectionAttempt();
+			// That connection attempt failed. The socket can close without ever
+			// emitting an error, so pass a reason along – it ends up as the error
+			// of the `maxAttemptsFailed` event once the retries are exhausted.
+			this.rejectConnectionAttempt(
+				new Error(
+					`WebSocket closed before the connection was established (code: ${event?.code}, reason: ${event?.reason || "none"})`,
+				),
+			);
 		}
 
 		// Let’s update the connection status.

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -102,6 +102,10 @@ export type onCloseParameters = {
 	event: CloseEvent;
 };
 
+export type onMaxAttemptsFailedParameters = {
+	error: unknown;
+};
+
 export type onAwarenessUpdateParameters = {
 	states: StatesArray;
 };

--- a/tests/providerwebsocket/maxAttempts.ts
+++ b/tests/providerwebsocket/maxAttempts.ts
@@ -1,0 +1,74 @@
+import { HocuspocusProviderWebsocket } from "@hocuspocus/provider";
+import test from "ava";
+import { sleep } from "../utils/index.ts";
+
+const exhaustedRetryOptions = {
+	url: "ws://127.0.0.1:1",
+	maxAttempts: 1,
+	delay: 1,
+	minDelay: 1,
+	initialDelay: 0,
+	jitter: false,
+};
+
+test("does not produce an unhandled rejection when maxAttempts are exhausted", async (t) => {
+	const unhandled: unknown[] = [];
+	const onUnhandledRejection = (reason: unknown) => {
+		unhandled.push(reason);
+	};
+	process.on("unhandledRejection", onUnhandledRejection);
+	t.teardown(() => {
+		process.off("unhandledRejection", onUnhandledRejection);
+	});
+
+	const ws = new HocuspocusProviderWebsocket(exhaustedRetryOptions);
+	t.teardown(() => ws.destroy());
+
+	await sleep(300);
+	await new Promise((resolve) => setImmediate(resolve));
+	await new Promise((resolve) => setImmediate(resolve));
+
+	t.is(unhandled.length, 0);
+});
+
+test("onMaxAttemptsFailed is executed when maxAttempts are exhausted", async (t) => {
+	await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error("onMaxAttemptsFailed was not called"));
+		}, 2000);
+
+		const ws = new HocuspocusProviderWebsocket({
+			...exhaustedRetryOptions,
+			onMaxAttemptsFailed({ error }) {
+				clearTimeout(timeout);
+				t.truthy(error);
+				ws.destroy();
+				resolve("done");
+			},
+		});
+		t.teardown(() => ws.destroy());
+	});
+});
+
+test("on('maxAttemptsFailed') is executed when maxAttempts are exhausted", async (t) => {
+	await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error("maxAttemptsFailed was not emitted"));
+		}, 2000);
+
+		const ws = new HocuspocusProviderWebsocket({
+			...exhaustedRetryOptions,
+			autoConnect: false,
+		});
+		t.teardown(() => ws.destroy());
+
+		ws.on("maxAttemptsFailed", ({ error }) => {
+			clearTimeout(timeout);
+			t.truthy(error);
+			ws.destroy();
+			resolve("done");
+		});
+
+		ws.connect();
+	});
+});

--- a/tests/providerwebsocket/maxAttempts.ts
+++ b/tests/providerwebsocket/maxAttempts.ts
@@ -1,4 +1,7 @@
-import { HocuspocusProviderWebsocket } from "@hocuspocus/provider";
+import {
+	HocuspocusProviderWebsocket,
+	type onMaxAttemptsFailedParameters,
+} from "@hocuspocus/provider";
 import test from "ava";
 import { sleep } from "../utils/index.ts";
 
@@ -62,7 +65,7 @@ test("on('maxAttemptsFailed') is executed when maxAttempts are exhausted", async
 		});
 		t.teardown(() => ws.destroy());
 
-		ws.on("maxAttemptsFailed", ({ error }) => {
+		ws.on("maxAttemptsFailed", ({ error }: onMaxAttemptsFailedParameters) => {
 			clearTimeout(timeout);
 			t.truthy(error);
 			ws.destroy();
@@ -71,4 +74,78 @@ test("on('maxAttemptsFailed') is executed when maxAttempts are exhausted", async
 
 		ws.connect();
 	});
+});
+
+// A server that accepts the upgrade and immediately closes the socket never
+// makes the client emit an `error` event – only a `close` one.
+class ClosingWebSocket {
+	binaryType = "arraybuffer";
+	identifier = 0;
+	listeners: Record<string, ((payload: any) => void)[]> = {};
+
+	constructor(_url: string) {
+		setTimeout(() => {
+			for (const handler of this.listeners.close ?? []) {
+				handler({ code: 1006, reason: "" });
+			}
+		}, 0);
+	}
+
+	addEventListener(name: string, handler: (payload: any) => void) {
+		this.listeners[name] = [...(this.listeners[name] ?? []), handler];
+	}
+
+	removeEventListener(name: string, handler: (payload: any) => void) {
+		this.listeners[name] = (this.listeners[name] ?? []).filter(
+			(listener) => listener !== handler,
+		);
+	}
+
+	close() {}
+
+	send() {}
+}
+
+test("emits maxAttemptsFailed when the socket closes without an error", async (t) => {
+	await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error("maxAttemptsFailed was not emitted"));
+		}, 2000);
+
+		const ws = new HocuspocusProviderWebsocket({
+			...exhaustedRetryOptions,
+			WebSocketPolyfill: ClosingWebSocket,
+			onMaxAttemptsFailed({ error }) {
+				clearTimeout(timeout);
+				t.truthy(error);
+				ws.destroy();
+				resolve("done");
+			},
+		});
+		t.teardown(() => ws.destroy());
+	});
+});
+
+test("does not emit maxAttemptsFailed when the connection attempt is aborted", async (t) => {
+	let failed = false;
+
+	const ws = new HocuspocusProviderWebsocket({
+		url: "ws://127.0.0.1:1",
+		maxAttempts: 5,
+		delay: 50,
+		minDelay: 50,
+		initialDelay: 0,
+		jitter: false,
+		onMaxAttemptsFailed() {
+			failed = true;
+		},
+	});
+	t.teardown(() => ws.destroy());
+
+	// Give the first attempt a chance to fail, then stop retrying.
+	await sleep(60);
+	ws.disconnect();
+	await sleep(400);
+
+	t.false(failed);
 });


### PR DESCRIPTION
## Summary
After maxAttempts is exhausted, connect() used to rethrow without a catch, causing Uncaught (in promise).
Stop rethrowing and emit maxAttemptsFailed instead (onMaxAttemptsFailed / on maxAttemptsFailed).

Fixes #947

## Test plan
- [x] ava tests/providerwebsocket/maxAttempts.ts
