### PR TITLE
fix(extension-redis): publish sync replies to the requester only

### DIFF
--- a/packages/extension-redis/src/Redis.ts
+++ b/packages/extension-redis/src/Redis.ts
@@ -158,6 +158,13 @@ export class Redis implements Extension {
 
 	messagePrefix: Buffer;
 
+	/**
+	 * Resolves once this instance is subscribed to its own reply channel.
+	 * Awaited before a document announces itself, so a peer's reply can never
+	 * arrive on a channel we are not listening to yet.
+	 */
+	private replySubscription: Promise<void>;
+
 	private pendingAfterStoreDocumentResolves = new Map<
 		string,
 		{ timeout: NodeJS.Timeout; resolve: () => void }
@@ -225,6 +232,31 @@ export class Redis implements Extension {
 			Buffer.from([identifierBuffer.length]),
 			identifierBuffer,
 		]);
+
+		// Subscribed once for the lifetime of the extension rather than per
+		// document: `handleIncomingMessage` resolves the document from the message
+		// payload, so a single channel per instance receives every reply addressed
+		// to us. Started here instead of in `onConfigure` because the server does
+		// not await that hook; `afterLoadDocument` awaits this promise, so no
+		// reply can be missed while the subscription is still pending.
+		this.replySubscription = new Promise<void>((resolve, reject) => {
+			this.sub.subscribe(
+				this.replyKey(this.configuration.identifier),
+				(error: any) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+
+					resolve();
+				},
+			);
+		});
+
+		// The error is re-thrown to whoever awaits the promise in
+		// `afterLoadDocument`; this handler only keeps it from being reported as
+		// an unhandled rejection when no document is ever loaded.
+		this.replySubscription.catch(() => {});
 	}
 
 	async onConfigure({ instance }: onConfigurePayload) {
@@ -247,11 +279,22 @@ export class Redis implements Extension {
 		return `${this.getKey(documentName)}:lock`;
 	}
 
+	/**
+	 * The channel an instance receives replies to its own requests on.
+	 *
+	 * Separated from the prefix by `#` rather than `:`, so it can never collide
+	 * with the document channel of a document that happens to be named
+	 * `reply:<identifier>`.
+	 */
+	private replyKey(identifier: string) {
+		return `${this.configuration.prefix}#reply:${identifier}`;
+	}
+
 	private encodeMessage(message: Uint8Array) {
 		return Buffer.concat([this.messagePrefix, Buffer.from(message)]);
 	}
 
-	private decodeMessage(buffer: Buffer) {
+	private decodeMessage(buffer: Buffer): [identifier: string, message: Buffer] {
 		const identifierLength = buffer[0];
 		const identifier = buffer.toString("utf-8", 1, identifierLength + 1);
 
@@ -273,6 +316,11 @@ export class Redis implements Extension {
 		this.documents.set(documentName, document);
 
 		try {
+			// Replies to the SyncStep1 we are about to publish are addressed to
+			// this instance's reply channel, so that subscription has to be live
+			// first.
+			await this.replySubscription;
+
 			await new Promise<void>((resolve, reject) => {
 				// On document creation the node will connect to pub and sub channels
 				// for the document.
@@ -378,6 +426,10 @@ export class Redis implements Extension {
 	 * Peek whether a message carries another instance's document state
 	 * (SyncStep2 or Update) without consuming the decoder. A SyncStep1 only
 	 * *requests* state, so it must not release an initial-sync wait.
+	 *
+	 * Carrying state is necessary but not sufficient to release that wait: the
+	 * state also has to have been computed for *our* state vector, which is what
+	 * arriving on our reply channel means. See `handleIncomingMessage`.
 	 */
 	private messageCarriesPeerState(message: IncomingMessage): boolean {
 		const { pos } = message.decoder;
@@ -681,17 +733,31 @@ export class Redis implements Extension {
 
 		const carriesPeerState = this.messageCarriesPeerState(message);
 
+		// State that reached us on our own reply channel was computed for our
+		// state vector; state overheard anywhere else was computed for somebody
+		// else and says nothing about whether we have caught up.
+		const addressedToUs =
+			channel.toString("utf-8") ===
+			this.replyKey(this.configuration.identifier);
+
 		const receiver = new MessageReceiver(message, this.redisTransactionOrigin);
 		await receiver.apply(document, undefined, (reply) => {
+			// Replies go to the requester alone, never to the document channel.
+			// A SyncStep2 is `encodeStateAsUpdate(document, requesterStateVector)`:
+			// the structs that one requester is missing plus the *entire* delete
+			// set. An instance whose state is behind the requester's applies those
+			// deletes without receiving the structs that replaced the deleted
+			// content, leaving it with a document that never existed — which it
+			// then broadcasts to its own clients and can persist (#1151).
 			return this.pub.publish(
-				this.pubKey(document.name),
+				this.replyKey(identifier),
 				this.encodeMessage(reply),
 			);
 		});
 
 		// A peer answered our SyncStep1 with its state — the document has now
 		// caught up, so any blocking initial-sync wait can be released.
-		if (carriesPeerState) {
+		if (carriesPeerState && addressedToUs) {
 			this.resolveInitialSync(documentName);
 		}
 	};

--- a/tests/extension-redis/syncStep2Routing.ts
+++ b/tests/extension-redis/syncStep2Routing.ts
@@ -1,0 +1,173 @@
+import { Redis } from "@hocuspocus/extension-redis";
+import { IncomingMessage, MessageType } from "@hocuspocus/server";
+import test from "ava";
+import {
+	newHocuspocus,
+	redisConnectionSettings,
+	sleep,
+} from "../utils/index.ts";
+
+const newRedisServer = async (t: any, prefix: string, identifier: string) => {
+	const extension = new Redis({
+		...redisConnectionSettings,
+		identifier: `${identifier}-${crypto.randomUUID()}`,
+		prefix,
+		disconnectDelay: 100,
+	});
+
+	const server = await newHocuspocus(t, { extensions: [extension] });
+
+	return { server, extension };
+};
+
+/** Simulate lost pub/sub delivery: stop feeding inbound messages to the extension. */
+const silence = (extension: Redis) => {
+	const sub = (extension as any).sub;
+	const handler = (extension as any).handleIncomingMessage;
+	sub.removeListener("messageBuffer", handler);
+
+	return () => sub.on("messageBuffer", handler);
+};
+
+test("a SyncStep2 computed for another instance must not truncate a stale bystander", async (t) => {
+	const prefix = `extension-redis/crossInstanceSyncStep2-${crypto.randomUUID()}`;
+	const docName = "poison";
+
+	const a = await newRedisServer(t, prefix, "serverA");
+	const b = await newRedisServer(t, prefix, "serverB");
+	const c = await newRedisServer(t, prefix, "serverC");
+
+	const directA = await a.server.openDirectConnection(docName);
+	const directB = await b.server.openDirectConnection(docName);
+	const directC = await c.server.openDirectConnection(docName);
+
+	// All three instances hold the document and agree on "OLD".
+	await directA.transact((doc) => {
+		doc.getText("t").insert(0, "OLD");
+	});
+	await sleep(500);
+
+	t.is(directA.document!.getText("t").toString(), "OLD", "A starts at OLD");
+	t.is(directB.document!.getText("t").toString(), "OLD", "B starts at OLD");
+	t.is(directC.document!.getText("t").toString(), "OLD", "C starts at OLD");
+
+	// A misses the rewrite (Redis pub/sub is fire-and-forget, so a dropped
+	// message, a reconnect, or a busy process all produce this).
+	const unsilence = silence(a.extension);
+
+	await directB.transact((doc) => {
+		const text = doc.getText("t");
+		text.delete(0, text.length);
+		text.insert(0, "NEW");
+	});
+	await sleep(500);
+
+	t.is(directB.document!.getText("t").toString(), "NEW", "B rewrote to NEW");
+	t.is(directC.document!.getText("t").toString(), "NEW", "C received NEW");
+	t.is(directA.document!.getText("t").toString(), "OLD", "A is stale at OLD");
+
+	unsilence();
+
+	// Record every state A's document passes through from here on.
+	const seen: string[] = [];
+	directA.document!.on("update", () => {
+		seen.push(directA.document!.getText("t").toString());
+	});
+
+	// Any change on C publishes a SyncStep1 with C's (up-to-date) state vector.
+	// B answers it with SyncStep2 = encodeStateAsUpdate(B, C.sv) — zero structs
+	// plus the full delete set — on the shared document channel, where A also
+	// hears it.
+	await directC.transact((doc) => {
+		doc.getMap("noise").set("k", 1);
+	});
+	await sleep(500);
+
+	t.log("states A passed through:", JSON.stringify(seen));
+	t.log("A final:", JSON.stringify(directA.document!.getText("t").toString()));
+
+	t.false(
+		seen.includes(""),
+		"A must never observe an empty document: it would broadcast that to its own clients and can persist it",
+	);
+
+	await directA.disconnect();
+	await directB.disconnect();
+	await directC.disconnect();
+});
+
+/** `messageYjsSyncStep2` from y-protocols/sync, which is not resolvable here. */
+const SYNC_STEP_2 = 1;
+
+test("sync replies are published to the requester's reply channel only", async (t) => {
+	const prefix = `extension-redis/syncStep2Routing-channel-${crypto.randomUUID()}`;
+	const docName = "routing";
+
+	const identifierA = `serverA-${crypto.randomUUID()}`;
+	const extensionA = new Redis({
+		...redisConnectionSettings,
+		identifier: identifierA,
+		prefix,
+		disconnectDelay: 100,
+	});
+	const serverA = await newHocuspocus(t, { extensions: [extensionA] });
+
+	const b = await newRedisServer(t, prefix, "serverB");
+
+	const published: Array<{ channel: string; syncType?: number }> = [];
+	const publisher = (b.extension as any).pub;
+	const original = publisher.publish.bind(publisher);
+
+	publisher.publish = (channel: string, payload: Buffer) => {
+		const [, messageBuffer] = (b.extension as any).decodeMessage(payload);
+		const message = new IncomingMessage(messageBuffer);
+
+		message.readVarString(); // document name
+
+		const type = message.readVarUint();
+
+		published.push({
+			channel,
+			syncType:
+				type === MessageType.Sync || type === MessageType.SyncReply
+					? message.readVarUint()
+					: undefined,
+		});
+
+		return original(channel, payload);
+	};
+
+	// B holds the document with state that only lives in its memory.
+	const directB = await b.server.openDirectConnection(docName);
+	await directB.transact((doc) => {
+		doc.getText("t").insert(0, "hello");
+	});
+	await sleep(300);
+	published.length = 0;
+
+	// A loads the same document, so B has to answer A's SyncStep1.
+	const directA = await serverA.openDirectConnection(docName);
+	await sleep(300);
+
+	t.is(directA.document!.getText("t").toString(), "hello", "A synced from B");
+
+	const replies = published.filter((entry) => entry.syncType === SYNC_STEP_2);
+
+	t.true(replies.length > 0, "B answered with its state");
+
+	for (const reply of replies) {
+		t.is(reply.channel, `${prefix}#reply:${identifierA}`);
+	}
+
+	t.false(
+		published.some(
+			(entry) =>
+				entry.channel === `${prefix}:${docName}` &&
+				entry.syncType === SYNC_STEP_2,
+		),
+		"no state is published on the shared document channel",
+	);
+
+	await directA.disconnect();
+	await directB.disconnect();
+});


### PR DESCRIPTION
Every MessageReceiver reply was published to the shared document channel. A SyncStep2 is `encodeStateAsUpdate(document, requesterStateVector)`: the structs that one requester is missing plus the *entire* delete set. An instance whose state is behind the requester's applies those deletes without receiving the structs that replaced the deleted content, so it ends up with a document that never existed globally — which it broadcasts to its own clients and can persist. Because redis-origin updates skip the store hooks, it also never re-stores the state it recovers a round trip later, so that truncated write can be the last one to reach storage.

Replies now go to `${prefix}#reply:${identifier}`, the channel of the instance that sent the request. Each instance subscribes to its own reply channel once (in the constructor, since the server does not await onConfigure), and afterLoadDocument awaits that subscription before publishing its SyncStep1, so a reply cannot arrive on a channel we are not listening to yet. SyncStep1, awareness and stateless messages keep using the shared document channel.

The initial-sync wait is released only by state that arrived on our own reply channel. messageCarriesPeerState checked the sync sub-type but never the addressee, so a load could unblock on — and a DirectConnection then read — a document truncated by a reply computed for another instance.

All instances of a cluster have to run the same version: replies are the only state-bearing messages the extension publishes, so an instance that does not subscribe to its reply channel receives no state.

Fixes #1151