### PR TITLE
fix: correct the onLoadDocument callback type and skip the document self-apply

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -419,7 +419,11 @@ export class Hocuspocus<Context = any> {
 			await this.hooks(
 				"onLoadDocument",
 				hookPayload,
-				(loadedDocument: Doc | Uint8ArrayConstructor | undefined) => {
+				(loadedDocument: Doc | Uint8Array | undefined) => {
+					// the hook returned the document it was given, and encoding a
+					// document's own state to apply it back can never add content
+					if (loadedDocument === document) return;
+
 					if (loadedDocument instanceof Doc) {
 						applyUpdate(document, encodeStateAsUpdate(loadedDocument));
 					} else if (loadedDocument instanceof Uint8Array) {

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -1,4 +1,5 @@
 import test from "ava";
+import * as Y from "yjs";
 import { newHocuspocus, newHocuspocusProvider } from "../utils/index.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -96,6 +97,69 @@ test("creates a new document in the onLoadDocument callback", async (t) => {
 			onSynced() {
 				const value = provider.document.getArray("foo").get(0);
 				t.is(value, "bar");
+
+				resolve("done");
+			},
+		});
+	});
+});
+
+test("does not apply the document to itself when onLoadDocument returns it", async (t) => {
+	const origins: unknown[] = [];
+
+	await new Promise(async (resolve) => {
+		const server = await newHocuspocus(t, {
+			async onLoadDocument({ document }) {
+				document.on("afterTransaction", (transaction) => {
+					origins.push(transaction.origin);
+				});
+
+				// the content this hook "loaded", written with an explicit origin so
+				// it doubles as a control: without it, a listener that never fires
+				// would satisfy the assertion below vacuously
+				document.transact(() => {
+					document.getArray("foo").insert(0, ["bar"]);
+				}, "loaded");
+
+				return document;
+			},
+		});
+
+		newHocuspocusProvider(t, server, {
+			onSynced() {
+				resolve("done");
+			},
+		});
+	});
+
+	t.true(origins.includes("loaded"), "the afterTransaction listener never fired");
+
+	// the self-apply calls applyUpdate() without an origin, and the client sync
+	// carries a ConnectionTransactionOrigin, so a null origin can only be the
+	// document having been applied to itself
+	const selfApplies = origins.filter((origin) => origin == null);
+
+	t.is(
+		selfApplies.length,
+		0,
+		`expected no null-origin transaction after onLoadDocument returned the same document, got ${selfApplies.length}`,
+	);
+});
+
+test("applies a document returned by the onLoadDocument callback", async (t) => {
+	await new Promise(async (resolve) => {
+		const server = await newHocuspocus(t, {
+			async onLoadDocument() {
+				const loaded = new Y.Doc();
+				loaded.getArray("foo").insert(0, ["bar"]);
+
+				return loaded;
+			},
+		});
+
+		const provider = newHocuspocusProvider(t, server, {
+			onSynced() {
+				t.is(provider.document.getArray("foo").get(0), "bar");
 
 				resolve("done");
 			},


### PR DESCRIPTION
The callback that handles `onLoadDocument` return values has two problems.

The parameter is annotated `Uint8ArrayConstructor` instead of `Uint8Array`. It only
typechecks because the `instanceof` check narrows it at runtime. 667e145 added that
branch and describes the hook as accepting "a yjs update (Uint8Array or Buffer) or a
Y.Doc", so the annotation says the opposite of what the branch is for.

The same callback also applies a document to itself. When a hook returns the document
it was given, `loadDocument` runs `applyUpdate(document, encodeStateAsUpdate(document))`.
Encoding a document's own state and applying it back can never add content, but it costs
a full encode and apply on the first connection to every document.

The bundled Database extension used to return the document, and c4c6094 removed that
return for this reason (#849, closing #848). The core was never guarded, so any hook that
still returns its document keeps paying the round trip.

This skips the apply when the returned instance is the same one. Returning a different
`Y.Doc` or a `Uint8Array` is unchanged.

Two tests:

- `does not apply the document to itself when onLoadDocument returns it` — records
  transaction origins after the hook returns and asserts none is null. The self-apply
  calls `applyUpdate` with no origin, while the client sync carries a
  `ConnectionTransactionOrigin`, so a null origin can only be the self-apply. Fails on
  main with 1.
- `applies a document returned by the onLoadDocument callback` — no existing test returned
  a *different* `Y.Doc`, so the merge branch had no coverage once the skip is in place.
  This pins it.
