### PR TITLE
fix: destroy the document when onLoadDocument throws

### DIFF
--- a/packages/server/src/Hocuspocus.ts
+++ b/packages/server/src/Hocuspocus.ts
@@ -429,7 +429,10 @@ export class Hocuspocus<Context = any> {
 			);
 		} catch (e) {
 			this.closeConnections(documentName);
-			this.unloadDocument(document);
+			// the document is not in `this.documents` yet — `createDocument` only
+			// registers it once this promise resolves — so `unloadDocument` would
+			// bail out before destroying it
+			document.destroy();
 			throw e;
 		}
 

--- a/tests/server/onLoadDocument.ts
+++ b/tests/server/onLoadDocument.ts
@@ -1,4 +1,5 @@
 import test from "ava";
+import type * as Y from "yjs";
 import { newHocuspocus, newHocuspocusProvider } from "../utils/index.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -280,6 +281,36 @@ test("disconnects all clients related to the document when an error is thrown in
 			},
 		});
 	});
+});
+
+test("destroys the document when onLoadDocument throws", async (t) => {
+	let loadedDocument: Y.Doc | undefined;
+
+	await new Promise(async (resolve) => {
+		const server = await newHocuspocus(t, {
+			async onLoadDocument({ document }) {
+				loadedDocument = document;
+
+				throw new Error("Something went wrong");
+			},
+		});
+
+		newHocuspocusProvider(t, server, {
+			onAuthenticationFailed() {
+				resolve("done");
+			},
+		});
+	});
+
+	t.truthy(loadedDocument, "onLoadDocument never ran");
+
+	// Awareness starts a setInterval in its constructor that is only cleared by
+	// the document's destroy(), so a document that is never destroyed leaves a
+	// live timer behind for every failed load
+	t.true(
+		loadedDocument?.isDestroyed,
+		"the document created for the failed load was never destroyed",
+	);
 });
 
 test("if a new connection connects while the previous connection still fetches the document, it will just work properly", async (t) => {


### PR DESCRIPTION
Fixes  #1156 

`createDocument` only registers a document in `this.documents` once `loadDocument`
resolves, so while `onLoadDocument` runs the document is not in the map. When the hook
throws, the catch calls `unloadDocument(document)`, which returns immediately on
`if (!this.documents.has(documentName)) return;`, so `document.destroy()` never runs.

y-protocols starts a `setInterval` in the `Awareness` constructor and only clears it in
`destroy()`, which is wired to the document's destroy event. Every failed load therefore
leaks a `Y.Doc` and a live timer. Rejecting unknown document names in `onLoadDocument` is
the documented way to refuse a connection, so this accumulates on a server that does it.

This destroys the document directly on the failure path. Going through `unloadDocument`
would fire `beforeUnloadDocument` and `afterUnloadDocument` for a document that never
finished loading — the redis extension subscribes in `afterLoadDocument`, so those hooks
would wait `disconnectDelay` and then unsubscribe a channel it never subscribed to.

The existing test asserts `server.documents.size === 0` after a failed load, which is
trivially true because the document was never registered. The new test captures the
document the hook was given and asserts it is destroyed. It fails on main.
